### PR TITLE
Modularize viam-chartplotter utilities

### DIFF
--- a/lib/chart/features.d.ts
+++ b/lib/chart/features.d.ts
@@ -1,0 +1,31 @@
+import Feature from 'ol/Feature.js';
+import Point from 'ol/geom/Point.js';
+import Circle from 'ol/geom/Circle.js';
+import LineString from 'ol/geom/LineString.js';
+import Collection from 'ol/Collection.js';
+/**
+ * Create a boat marker feature at specified coordinates
+ */
+export declare function createBoatMarker(coordinates?: number[]): Feature<Point>;
+/**
+ * Create AIS feature for vessel tracking
+ */
+export declare function createAISFeature(mmsi: string, boat: any): Feature<Point>;
+/**
+ * Create track point feature
+ */
+export declare function createTrackPoint(coordinates: number[]): Feature<Circle>;
+/**
+ * Create track line feature connecting two points
+ */
+export declare function createTrackLine(startCoords: number[], endCoords: number[]): Feature<LineString>;
+/**
+ * Process NMEA 2000 PGN 129285
+ * Clears existing route features and creates new ones from waypoint list
+ */
+export declare function processRoute129285(doc: any, routeFeatures: Collection<Feature>): void;
+/**
+ * Update AIS features collection with new vessel data
+ * Removes stale vessels and updates/adds current ones
+ */
+export declare function updateAISFeatures(aisFeatures: Collection<Feature>, rawAISData: any): void;

--- a/lib/chart/features.js
+++ b/lib/chart/features.js
@@ -1,0 +1,103 @@
+import Feature from 'ol/Feature.js';
+import Point from 'ol/geom/Point.js';
+import Circle from 'ol/geom/Circle.js';
+import LineString from 'ol/geom/LineString.js';
+/**
+ * Create a boat marker feature at specified coordinates
+ */
+export function createBoatMarker(coordinates = [0, 0]) {
+    return new Feature({
+        type: 'geoMarker',
+        header: 0,
+        geometry: new Point(coordinates),
+    });
+}
+/**
+ * Create AIS feature for vessel tracking
+ */
+export function createAISFeature(mmsi, boat) {
+    return new Feature({
+        type: "ais",
+        mmsi: mmsi,
+        heading: boat.Heading,
+        geometry: new Point([boat.Location[1], boat.Location[0]]),
+    });
+}
+/**
+ * Create track point feature
+ */
+export function createTrackPoint(coordinates) {
+    return new Feature({
+        type: "track",
+        geometry: new Circle(coordinates)
+    });
+}
+/**
+ * Create track line feature connecting two points
+ */
+export function createTrackLine(startCoords, endCoords) {
+    return new Feature({
+        type: "track",
+        geometry: new LineString([startCoords, endCoords])
+    });
+}
+/**
+ * Process NMEA 2000 PGN 129285
+ * Clears existing route features and creates new ones from waypoint list
+ */
+export function processRoute129285(doc, routeFeatures) {
+    console.log(doc);
+    routeFeatures.clear();
+    if (!doc.list) {
+        return;
+    }
+    let prev = [];
+    for (let x = 0; x < doc.list.length; x++) {
+        const wp = doc.list[x];
+        const loc = [wp["WP Longitude"], wp["WP Latitude"]];
+        if (prev.length > 0) {
+            const f = new Feature({
+                type: "track",
+                geometry: new LineString([prev, loc]),
+            });
+            routeFeatures.push(f);
+        }
+        prev = loc;
+    }
+    console.log(routeFeatures);
+}
+/**
+ * Update AIS features collection with new vessel data
+ * Removes stale vessels and updates/adds current ones
+ */
+export function updateAISFeatures(aisFeatures, rawAISData) {
+    const good = {};
+    for (const mmsi in rawAISData) {
+        const boat = rawAISData[mmsi];
+        if (boat == null || boat.Location == null || boat.Location.length != 2 || boat.Location[0] == null) {
+            continue;
+        }
+        good[mmsi] = true;
+        let found = false;
+        for (let i = 0; i < aisFeatures.getLength(); i++) {
+            const v = aisFeatures.item(i);
+            if (v.get("mmsi") == mmsi) {
+                found = true;
+                v.setGeometry(new Point([boat.Location[1], boat.Location[0]]));
+                break;
+            }
+        }
+        if (!found) {
+            aisFeatures.push(createAISFeature(mmsi, boat));
+        }
+    }
+    // Remove stale AIS features
+    for (let i = 0; i < aisFeatures.getLength(); i++) {
+        const v = aisFeatures.item(i);
+        const mmsi = v.get("mmsi");
+        if (!good[mmsi]) {
+            aisFeatures.removeAt(i);
+            i--; // Adjust index after removal
+        }
+    }
+}

--- a/lib/chart/layers.d.ts
+++ b/lib/chart/layers.d.ts
@@ -1,0 +1,24 @@
+import TileLayer from 'ol/layer/Tile';
+import TileWMS from 'ol/source/TileWMS.js';
+import XYZ from 'ol/source/XYZ';
+/**
+ * Custom tile URL function (for seamark tiles)
+ * Handles coordinate wrapping and URL selection
+ */
+export declare function getTileUrlFunction(url: string | string[], type: string, coordinates: number[]): string;
+/**
+ * Create OpenStreetMap tile layer
+ */
+export declare function createOSMLayer(): TileLayer<XYZ>;
+/**
+ * Create depth/bathymetry layer from OpenSeaMap
+ */
+export declare function createDepthLayer(): TileLayer<TileWMS>;
+/**
+ * Create seamark layer from OpenSeaMap
+ */
+export declare function createSeamarkLayer(): TileLayer<XYZ>;
+/**
+ * Create NOAA chart layer
+ */
+export declare function createNOAALayer(): TileLayer<TileWMS>;

--- a/lib/chart/layers.js
+++ b/lib/chart/layers.js
@@ -1,0 +1,81 @@
+import TileLayer from 'ol/layer/Tile';
+import TileWMS from 'ol/source/TileWMS.js';
+import XYZ from 'ol/source/XYZ';
+/**
+ * Custom tile URL function (for seamark tiles)
+ * Handles coordinate wrapping and URL selection
+ */
+export function getTileUrlFunction(url, type, coordinates) {
+    const x = coordinates[1];
+    let y = coordinates[2];
+    const z = coordinates[0];
+    const limit = Math.pow(2, z);
+    if (y < 0 || y >= limit) {
+        return null;
+    }
+    else {
+        const wrappedX = ((x % limit) + limit) % limit;
+        const path = z + "/" + wrappedX + "/" + y + "." + type;
+        if (url instanceof Array) {
+            url = url[0];
+        }
+        return url + path;
+    }
+}
+/**
+ * Create OpenStreetMap tile layer
+ */
+export function createOSMLayer() {
+    return new TileLayer({
+        opacity: .5,
+        source: new XYZ({
+            url: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png'
+        })
+    });
+}
+/**
+ * Create depth/bathymetry layer from OpenSeaMap
+ */
+export function createDepthLayer() {
+    return new TileLayer({
+        opacity: .7,
+        source: new TileWMS({
+            url: 'https://geoserver.openseamap.org/geoserver/gwc/service/wms',
+            params: { 'LAYERS': 'gebco2021:gebco_2021', 'VERSION': '1.1.1' },
+            serverType: 'geoserver',
+            hidpi: false,
+        }),
+    });
+}
+/**
+ * Create seamark layer from OpenSeaMap
+ */
+export function createSeamarkLayer() {
+    return new TileLayer({
+        visible: true,
+        maxZoom: 19,
+        source: new XYZ({
+            tileUrlFunction: function (coordinate) {
+                return getTileUrlFunction("https://tiles.openseamap.org/seamark/", 'png', coordinate);
+            }
+        }),
+        properties: {
+            name: "seamarks",
+            layerId: 3,
+            cookieKey: "SeamarkLayerVisible",
+            checkboxId: "checkLayerSeamark",
+        }
+    });
+}
+/**
+ * Create NOAA chart layer
+ */
+export function createNOAALayer() {
+    return new TileLayer({
+        opacity: .7,
+        source: new TileWMS({
+            url: "https://gis.charttools.noaa.gov/arcgis/rest/services/MCS/NOAAChartDisplay/MapServer/exts/MaritimeChartService/WMSServer",
+            params: {}
+        }),
+    });
+}

--- a/lib/chart/setup.d.ts
+++ b/lib/chart/setup.d.ts
@@ -1,0 +1,38 @@
+import Map from 'ol/Map';
+import View from 'ol/View';
+import Collection from 'ol/Collection.js';
+export interface LayerOption {
+    name: string;
+    on: boolean;
+    layer: any;
+}
+export interface MapGlobal {
+    map: Map | null;
+    view: View | null;
+    aisFeatures: Collection<any>;
+    trackFeatures: Collection<any>;
+    routeFeatures: Collection<any>;
+    trackFeaturesLastCheck: Date;
+    myBoatMarker: any;
+    inPanMode: boolean;
+    lastZoom: number;
+    lastCenter: number[] | null;
+    layerOptions: LayerOption[];
+    onLayers: Collection<any>;
+}
+/**
+ * Setup all layer options with their configurations
+ */
+export declare function setupLayers(aisFeatures: Collection<any>, trackFeatures: Collection<any>, routeFeatures: Collection<any>, boatImage: string, getGlobalDataHeading: () => number): LayerOption[];
+/**
+ * Find layer option by name
+ */
+export declare function findLayerByName(layerOptions: LayerOption[], name: string): LayerOption | null;
+/**
+ * Find index of layer in onLayers collection by name
+ */
+export declare function findOnLayerIndexOfName(layerOptions: LayerOption[], onLayers: Collection<any>, name: string): number;
+/**
+ * Update onLayers collection based on layer options
+ */
+export declare function updateOnLayers(layerOptions: LayerOption[], onLayers: Collection<any>): void;

--- a/lib/chart/setup.js
+++ b/lib/chart/setup.js
@@ -1,0 +1,173 @@
+import Collection from 'ol/Collection.js';
+import VectorSource from 'ol/source/Vector.js';
+import { Vector } from 'ol/layer.js';
+import { Icon, Style } from 'ol/style.js';
+import { Fill, Stroke } from 'ol/style.js';
+import { createOSMLayer, createDepthLayer, createSeamarkLayer, createNOAALayer } from './layers.js';
+import { createBoatMarker } from './features.js';
+/**
+ * Setup all layer options with their configurations
+ */
+export function setupLayers(aisFeatures, trackFeatures, routeFeatures, boatImage, getGlobalDataHeading) {
+    const layerOptions = [];
+    // Core open street maps
+    layerOptions.push({
+        name: "open street map",
+        on: false,
+        layer: createOSMLayer(),
+    });
+    // Depth data
+    layerOptions.push({
+        name: "depth",
+        on: false,
+        layer: createDepthLayer(),
+    });
+    // Harbors/seamarks
+    layerOptions.push({
+        name: "seamark",
+        on: false,
+        layer: createSeamarkLayer(),
+    });
+    // NOAA charts
+    layerOptions.push({
+        name: "noaa",
+        on: true,
+        layer: createNOAALayer(),
+    });
+    // Boat marker layer
+    const myBoatMarker = createBoatMarker();
+    const myBoatFeatures = new Collection();
+    myBoatFeatures.push(myBoatMarker);
+    const myBoatLayer = new Vector({
+        source: new VectorSource({
+            features: myBoatFeatures,
+        }),
+        style: function (feature) {
+            const scale = 0.6;
+            const rotation = (getGlobalDataHeading() / 360) * Math.PI * 2;
+            return new Style({
+                image: new Icon({
+                    src: boatImage,
+                    scale: scale,
+                    rotation: rotation,
+                }),
+            });
+        },
+    });
+    layerOptions.push({
+        name: "boat",
+        on: true,
+        layer: myBoatLayer,
+    });
+    // AIS layer
+    const aisLayer = new Vector({
+        source: new VectorSource({
+            features: aisFeatures,
+        }),
+        style: function (feature) {
+            const scale = 0.25;
+            let rotation = 0;
+            const h = feature.get("heading");
+            if (h >= 0 && h < 360) {
+                rotation = (h / 360) * Math.PI * 2;
+            }
+            return new Style({
+                image: new Icon({
+                    src: boatImage,
+                    scale: scale,
+                    rotation: rotation,
+                }),
+            });
+        },
+    });
+    layerOptions.push({
+        name: "ais",
+        on: true,
+        layer: aisLayer,
+    });
+    // Track layer
+    const trackLayer = new Vector({
+        source: new VectorSource({
+            features: trackFeatures,
+        }),
+        style: new Style({
+            stroke: new Stroke({
+                color: "blue",
+                width: 3
+            }),
+            fill: new Fill({
+                color: "rgba(0, 255, 0, 0.1)"
+            })
+        }),
+    });
+    layerOptions.push({
+        name: "track",
+        on: true,
+        layer: trackLayer,
+    });
+    // Route layer
+    const routeLayer = new Vector({
+        source: new VectorSource({
+            features: routeFeatures,
+        }),
+        style: new Style({
+            stroke: new Stroke({
+                color: "green",
+                width: 3
+            }),
+            fill: new Fill({
+                color: "rgba(0, 255, 0, 0.1)"
+            })
+        }),
+    });
+    layerOptions.push({
+        name: "route",
+        on: true,
+        layer: routeLayer,
+    });
+    return layerOptions;
+}
+/**
+ * Find layer option by name
+ */
+export function findLayerByName(layerOptions, name) {
+    for (const l of layerOptions) {
+        if (l.name === name) {
+            return l;
+        }
+    }
+    return null;
+}
+/**
+ * Find index of layer in onLayers collection by name
+ */
+export function findOnLayerIndexOfName(layerOptions, onLayers, name) {
+    const l = findLayerByName(layerOptions, name);
+    if (l == null) {
+        return -2;
+    }
+    for (let i = 0; i < onLayers.getLength(); i++) {
+        if (onLayers.item(i).ol_uid == l.layer.ol_uid) {
+            return i;
+        }
+    }
+    return -1;
+}
+/**
+ * Update onLayers collection based on layer options
+ */
+export function updateOnLayers(layerOptions, onLayers) {
+    for (const l of layerOptions) {
+        const idx = findOnLayerIndexOfName(layerOptions, onLayers, l.name);
+        if (l.on) {
+            if (idx < 0) {
+                onLayers.push(l.layer);
+            }
+        }
+        else {
+            if (idx >= 0) {
+                onLayers.removeAt(idx);
+            }
+        }
+    }
+}

--- a/lib/data/queries.d.ts
+++ b/lib/data/queries.d.ts
@@ -1,0 +1,15 @@
+/**
+ * Get gauge data via MQL query
+ * Retrieves historical gauge readings aggregated in 15-minute buckets
+ */
+export declare function getDataViaMQL(dc: any, g: string, startTime: Date, cloudMetaData: any): Promise<any>;
+/**
+ * Get position history via MQL query
+ * Tries configured sensor first, then falls back to alternatives
+ */
+export declare function positionHistoryMQL(dc: any, startTime: Date, globalConfig: any, cloudMetaData: any): Promise<any>;
+/**
+ * Get position history for a specific movement sensor
+ * Queries position data aggregated by minute
+ */
+export declare function positionHistoryMQLNamed(dc: any, startTime: Date, sensorName: string, cloudMetaData: any, hot: boolean): Promise<any>;

--- a/lib/data/queries.js
+++ b/lib/data/queries.js
@@ -1,0 +1,103 @@
+import { BSON } from "bsonfy";
+/**
+ * Get gauge data via MQL query
+ * Retrieves historical gauge readings aggregated in 15-minute buckets
+ */
+export async function getDataViaMQL(dc, g, startTime, cloudMetaData) {
+    const match = {
+        "location_id": cloudMetaData.locationId,
+        "robot_id": cloudMetaData.machineId,
+        "component_name": g,
+        time_received: { $gte: startTime }
+    };
+    const group = {
+        "_id": {
+            "$concat": [
+                { "$toString": { "$substr": [{ "$year": "$time_received" }, 2, -1] } },
+                "-",
+                { "$toString": { "$month": "$time_received" } },
+                "-",
+                { "$toString": { "$dayOfMonth": "$time_received" } },
+                " ",
+                { "$toString": { "$hour": "$time_received" } },
+                ":",
+                { "$toString": { "$multiply": [15, { "$floor": { "$divide": [{ "$minute": "$time_received" }, 15] } }] } }
+            ]
+        },
+        "ts": { "$min": "$time_received" },
+        "min": { "$min": "$data.readings.Level" },
+        "max": { "$max": "$data.readings.Level" }
+    };
+    const query = [
+        BSON.serialize({ "$match": match }),
+        BSON.serialize({ "$group": group }),
+        BSON.serialize({ "$sort": { ts: -1 } }),
+        BSON.serialize({ "$limit": (24 * 4) }),
+        BSON.serialize({ "$sort": { ts: 1 } }),
+    ];
+    const data = await dc.tabularDataByMQL(cloudMetaData.primaryOrgId, query, true);
+    return data;
+}
+/**
+ * Get position history via MQL query
+ * Tries configured sensor first, then falls back to alternatives
+ */
+export async function positionHistoryMQL(dc, startTime, globalConfig, cloudMetaData) {
+    if (globalConfig.movementSensorForQuery !== "") {
+        const res = await positionHistoryMQLNamed(dc, startTime, globalConfig.movementSensorForQuery, cloudMetaData, false);
+        if (res.length > 0) {
+            return res;
+        }
+    }
+    for (let i = 0; i < globalConfig.movementSensorAlternates.length; i++) {
+        const n = globalConfig.movementSensorAlternates[i];
+        const res = await positionHistoryMQLNamed(dc, startTime, n, cloudMetaData, false);
+        if (res.length > 0) {
+            globalConfig.movementSensorForQuery = n;
+            return res;
+        }
+    }
+    return [];
+}
+/**
+ * Get position history for a specific movement sensor
+ * Queries position data aggregated by minute
+ */
+export async function positionHistoryMQLNamed(dc, startTime, sensorName, cloudMetaData, hot) {
+    const name = sensorName.split(":");
+    const match = {
+        "location_id": cloudMetaData.locationId,
+        "robot_id": cloudMetaData.machineId,
+        "component_name": name[name.length - 1],
+        "method_name": "Position",
+        "time_received": { $gte: startTime }
+    };
+    const group = {
+        "_id": {
+            "$concat": [
+                { "$toString": { "$substr": [{ "$year": "$time_received" }, 2, -1] } },
+                "-",
+                { "$toString": { "$month": "$time_received" } },
+                "-",
+                { "$toString": { "$dayOfMonth": "$time_received" } },
+                " ",
+                { "$toString": { "$hour": "$time_received" } },
+                ":",
+                { "$toString": { "$minute": "$time_received" } },
+            ]
+        },
+        "ts": { "$min": "$time_received" },
+        "pos": { "$first": "$data" },
+    };
+    const query = [
+        BSON.serialize({ "$match": match }),
+        BSON.serialize({ "$sort": { ts: -1 } }),
+        BSON.serialize({ "$group": group }),
+        BSON.serialize({ "$sort": { ts: -1 } }),
+    ];
+    const timeStart = new Date();
+    const data = await dc.tabularDataByMQL(cloudMetaData.primaryOrgId, query, hot);
+    const getDataTime = (new Date()).getTime() - timeStart.getTime();
+    console.log("got " + data.length + " history data points from:" + sensorName + " in " + getDataTime + "ms");
+    return data;
+}

--- a/lib/data/sensors.d.ts
+++ b/lib/data/sensors.d.ts
@@ -1,0 +1,40 @@
+import * as VIAM from '@viamrobotics/sdk';
+/**
+ * Filter resources by type, subtype, and optional name pattern
+ * Returns matching resources from the provided list
+ */
+export declare function filterResources(resources: any[], type: string, subtype: string, namePattern?: RegExp | null): any[];
+/**
+ * Filter resources and return the first matching name
+ * Returns empty string if no matches found
+ */
+export declare function filterResourcesFirstMatchingName(resources: any[], type: string, subtype: string, namePattern?: RegExp | null): string;
+/**
+ * Filter resources and return all matching names sorted
+ * Returns array of resource names
+ */
+export declare function filterResourcesAllMatchingNames(resources: any[], type: string, subtype: string, namePattern?: RegExp | null): string[];
+/**
+ * Setup movement sensor by finding the best available sensor
+ * Prioritizes sensors with more capabilities (position, velocity, compass)
+ */
+export declare function setupMovementSensor(client: VIAM.RobotClient, resources: any[]): Promise<{
+    movementSensorName: string;
+    movementSensorProps: {};
+    movementSensorAlternates: any[];
+}>;
+/**
+ * Discover and configure all sensor names from resources
+ * Returns configuration object with sensor names for different types
+ */
+export declare function discoverSensorNames(resources: any[]): {
+    aisSensorName: string;
+    allPgnSensorName: string;
+    seatempSensorName: string;
+    depthSensorName: string;
+    windSensorName: string;
+    spotZeroFWSensorName: string;
+    spotZeroSWSensorName: string;
+    seakeeperSensorName: string;
+    acPowers: string[];
+};

--- a/lib/data/sensors.js
+++ b/lib/data/sensors.js
@@ -1,0 +1,99 @@
+import * as VIAM from '@viamrobotics/sdk';
+/**
+ * Filter resources by type, subtype, and optional name pattern
+ * Returns matching resources from the provided list
+ */
+export function filterResources(resources, type, subtype, namePattern = null) {
+    const filtered = [];
+    for (const resource of resources) {
+        if (type !== "" && resource.type !== type) {
+            continue;
+        }
+        if (subtype !== "" && resource.subtype !== subtype) {
+            continue;
+        }
+        if (namePattern != null && !resource.name.match(namePattern)) {
+            continue;
+        }
+        filtered.push(resource);
+    }
+    return filtered;
+}
+/**
+ * Filter resources and return the first matching name
+ * Returns empty string if no matches found
+ */
+export function filterResourcesFirstMatchingName(resources, type, subtype, namePattern = null) {
+    const matching = filterResources(resources, type, subtype, namePattern);
+    if (matching.length > 0) {
+        return matching[0].name;
+    }
+    return "";
+}
+/**
+ * Filter resources and return all matching names sorted
+ * Returns array of resource names
+ */
+export function filterResourcesAllMatchingNames(resources, type, subtype, namePattern = null) {
+    const matching = filterResources(resources, type, subtype, namePattern);
+    const names = [];
+    for (const resource of matching) {
+        names.push(resource.name);
+    }
+    return names.sort();
+}
+/**
+ * Setup movement sensor by finding the best available sensor
+ * Prioritizes sensors with more capabilities (position, velocity, compass)
+ */
+export async function setupMovementSensor(client, resources) {
+    const movementSensors = filterResources(resources, "component", "movement_sensor", null);
+    const allGpsNames = [];
+    // Pick best movement sensor
+    let bestName = "";
+    let bestScore = 0;
+    let bestProp = {};
+    for (const resource of movementSensors) {
+        const msClient = new VIAM.MovementSensorClient(client, resource.name);
+        const prop = await msClient.getProperties();
+        let score = 0;
+        if (prop.positionSupported) {
+            allGpsNames.push(resource.name);
+            score++;
+        }
+        if (prop.linearVelocitySupported) {
+            score++;
+        }
+        if (prop.compassHeadingSupported) {
+            score++;
+        }
+        // Prefer higher scores, tie-break with shorter names
+        if (score > bestScore || (score === bestScore && resource.name.length < bestName.length)) {
+            bestName = resource.name;
+            bestScore = score;
+            bestProp = prop;
+        }
+    }
+    return {
+        movementSensorName: bestName,
+        movementSensorProps: bestProp,
+        movementSensorAlternates: allGpsNames
+    };
+}
+/**
+ * Discover and configure all sensor names from resources
+ * Returns configuration object with sensor names for different types
+ */
+export function discoverSensorNames(resources) {
+    return {
+        aisSensorName: filterResourcesFirstMatchingName(resources, "component", "sensor", /\bais$/),
+        allPgnSensorName: filterResourcesFirstMatchingName(resources, "component", "sensor", /\ball.pgn$/),
+        seatempSensorName: filterResourcesFirstMatchingName(resources, "component", "sensor", /\bseatemp$/),
+        depthSensorName: filterResourcesFirstMatchingName(resources, "component", "sensor", /depth/),
+        windSensorName: filterResourcesFirstMatchingName(resources, "component", "sensor", /wind/),
+        spotZeroFWSensorName: filterResourcesFirstMatchingName(resources, "component", "sensor", /spotzero-fw/),
+        spotZeroSWSensorName: filterResourcesFirstMatchingName(resources, "component", "sensor", /spotzero-sw/),
+        seakeeperSensorName: filterResourcesFirstMatchingName(resources, "component", "sensor", /seakeeper/),
+        acPowers: filterResourcesAllMatchingNames(resources, "component", "sensor", /\bac-\d-\d$/)
+    };
+}

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,0 +1,1 @@
+// place files you want to import through the `$lib` alias in this folder.

--- a/lib/utils/conversions.d.ts
+++ b/lib/utils/conversions.d.ts
@@ -1,0 +1,38 @@
+/**
+ * Convert meters per second to knots
+ * Used for displaying boat speed in nautical units
+ */
+export declare function msToKnots(speedMs: number): number;
+/**
+ * Calculate point difference for pan detection
+ * Used to detect when user is manually panning the map
+ */
+export declare function pointDiff(x: number[], y: number[]): number;
+/**
+ * Convert Celsius to Fahrenheit
+ * Used for water temperature display
+ */
+export declare function celsiusToFahrenheit(celsius: number): number;
+/**
+ * Convert liters to gallons
+ * Used for fuel and water tank displays
+ */
+export declare function litersToGallons(liters: number): number;
+/**
+ * Calculate total fuel level across multiple tanks
+ * Returns total fuel in gallons
+ */
+export declare function fuelTotalLevel(gauges: Record<string, any>): number;
+/**
+ * Calculate total fuel capacity across multiple tanks
+ * Returns total capacity in gallons
+ */
+export declare function fuelTotalCapacity(gauges: Record<string, any>): number;
+/**
+ * Calculate average AC power voltage
+ */
+export declare function acPowerVoltAverage(data: Record<string, any>): number;
+/**
+ * Calculate total AC power amperage at specified voltage
+ */
+export declare function acPowerAmpAt(vvv: number, data: Record<string, any>): number;

--- a/lib/utils/conversions.js
+++ b/lib/utils/conversions.js
@@ -1,0 +1,88 @@
+/**
+ * Convert meters per second to knots
+ * Used for displaying boat speed in nautical units
+ */
+export function msToKnots(speedMs) {
+    return speedMs * 1.94384;
+}
+/**
+ * Calculate point difference for pan detection
+ * Used to detect when user is manually panning the map
+ */
+export function pointDiff(x, y) {
+    const a = x[0] - y[0];
+    const b = x[1] - y[1];
+    const c = a * a + b * b;
+    return Math.sqrt(c);
+}
+/**
+ * Convert Celsius to Fahrenheit
+ * Used for water temperature display
+ */
+export function celsiusToFahrenheit(celsius) {
+    return 32 + (celsius * 1.8);
+}
+/**
+ * Convert liters to gallons
+ * Used for fuel and water tank displays
+ */
+export function litersToGallons(liters) {
+    return liters * 0.264172;
+}
+/**
+ * Calculate total fuel level across multiple tanks
+ * Returns total fuel in gallons
+ */
+export function fuelTotalLevel(gauges) {
+    let total = 0;
+    for (const k in gauges) {
+        const g = gauges[k];
+        if (g["Type"] !== "Fuel") {
+            continue;
+        }
+        total += g["Level"] * g["Capacity"] / 100;
+    }
+    return Math.round(total * 0.264172);
+}
+/**
+ * Calculate total fuel capacity across multiple tanks
+ * Returns total capacity in gallons
+ */
+export function fuelTotalCapacity(gauges) {
+    let total = 0;
+    for (const k in gauges) {
+        const g = gauges[k];
+        if (g["Type"] !== "Fuel") {
+            continue;
+        }
+        total += g["Capacity"];
+    }
+    return Math.round(total * 0.264172);
+}
+/**
+ * Calculate average AC power voltage
+ */
+export function acPowerVoltAverage(data) {
+    let total = 0;
+    let num = 0;
+    for (const k in data) {
+        const dd = data[k];
+        total += dd["Line-Neutral AC RMS Voltage"];
+        num++;
+    }
+    return total / num;
+}
+/**
+ * Calculate total AC power amperage at specified voltage
+ */
+export function acPowerAmpAt(vvv, data) {
+    let total = 0;
+    for (const k in data) {
+        const dd = data[k];
+        const a = dd["AC RMS Current"];
+        const v = dd["Line-Neutral AC RMS Voltage"];
+        const w = a * v;
+        total += w / vvv;
+    }
+    return total;
+}

--- a/lib/utils/helpers.d.ts
+++ b/lib/utils/helpers.d.ts
@@ -1,0 +1,14 @@
+/**
+ * Convert dictionary to sorted array of key-value pairs
+ * Used for rendering gauge data in sorted order
+ */
+export declare function dicToArray(d: Record<string, any>, sortFunction?: (names: string[]) => string[]): [string, any][];
+/**
+ * Check if there's more than one fuel tank
+ * Used to determine whether to show total fuel display
+ */
+export declare function moreThanOneFuelTank(gauges: Record<string, any>): boolean;
+/**
+ * Convert gauge historical data to format expected by LinkedChart
+ */
+export declare function gauageHistoricalToLinkedChart(data: any): Record<string, number>;

--- a/lib/utils/helpers.js
+++ b/lib/utils/helpers.js
@@ -1,0 +1,47 @@
+/**
+ * Convert dictionary to sorted array of key-value pairs
+ * Used for rendering gauge data in sorted order
+ */
+export function dicToArray(d, sortFunction) {
+    let names = Object.keys(d);
+    if (sortFunction) {
+        names = sortFunction(names);
+    }
+    else {
+        names.sort();
+    }
+    const a = [];
+    for (let i = 0; i < names.length; i++) {
+        const n = names[i];
+        a.push([n, d[n]]);
+    }
+    return a;
+}
+/**
+ * Check if there's more than one fuel tank
+ * Used to determine whether to show total fuel display
+ */
+export function moreThanOneFuelTank(gauges) {
+    let found = false;
+    for (const k in gauges) {
+        const g = gauges[k];
+        if (g["Type"] === "Fuel") {
+            if (found) {
+                return true;
+            }
+            found = true;
+        }
+    }
+    return false;
+}
+/**
+ * Convert gauge historical data to format expected by LinkedChart
+ */
+export function gauageHistoricalToLinkedChart(data) {
+    const res = {};
+    for (const d in data.data) {
+        const dd = data.data[d];
+        res[dd._id] = Math.floor(dd.min);
+    }
+    return res;
+}

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
 		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
 		"lint": "eslint .",
-		"build": "vite build"
+		"build": "vite build",
+		"build:lib": "tsc -p tsconfig.lib.json"
 	},
 	"devDependencies": {
 		"@types/eslint": "8.56.0",
@@ -29,13 +30,13 @@
 	},
 	"type": "module",
 	"exports": {
-		"./chart/setup": "./src/lib/chart/setup.js",
-		"./chart/features": "./src/lib/chart/features.js",
-		"./chart/layers": "./src/lib/chart/layers.js",
-		"./data/queries": "./src/lib/data/queries.js",
-		"./data/sensors": "./src/lib/data/sensors.js",
-		"./utils/conversions": "./src/lib/utils/conversions.js",
-		"./utils/helpers": "./src/lib/utils/helpers.js"
+		"./chart/setup": "./lib/chart/setup.js",
+		"./chart/features": "./lib/chart/features.js",
+		"./chart/layers": "./lib/chart/layers.js",
+		"./data/queries": "./lib/data/queries.js",
+		"./data/sensors": "./lib/data/sensors.js",
+		"./utils/conversions": "./lib/utils/conversions.js",
+		"./utils/helpers": "./lib/utils/helpers.js"
 	},
 	"dependencies": {
 		"@ag-grid-community/client-side-row-model": "^32.3.5",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,15 @@
 		"vite": "^6.0.5"
 	},
 	"type": "module",
+	"exports": {
+		"./chart/setup": "./src/lib/chart/setup.js",
+		"./chart/features": "./src/lib/chart/features.js",
+		"./chart/layers": "./src/lib/chart/layers.js",
+		"./data/queries": "./src/lib/data/queries.js",
+		"./data/sensors": "./src/lib/data/sensors.js",
+		"./utils/conversions": "./src/lib/utils/conversions.js",
+		"./utils/helpers": "./src/lib/utils/helpers.js"
+	},
 	"dependencies": {
 		"@ag-grid-community/client-side-row-model": "^32.3.5",
 		"@ag-grid-community/core": "^32.3.5",

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -25,8 +25,6 @@
    LinkedValue
  } from "svelte-tiny-linked-charts"
 
- import * as VIAM from '@viamrobotics/sdk';
-
  import {
    setupLayers,
    updateOnLayers,
@@ -70,6 +68,8 @@
    setupMovementSensor,
    discoverSensorNames
  } from './lib/data/sensors.js';
+
+ import * as VIAM from '@viamrobotics/sdk';
 
  let boatImage = "boat3.jpg";
 

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -4,9 +4,9 @@
  import { onMount } from 'svelte';
  import { Icon as PrimeIcon } from '@viamrobotics/prime-core';
 
-
+ 
  import { Logger } from "tslog";
-
+ 
  import {Coordinate} from "tsgeo/Coordinate";
  import {DecimalMinutes}        from "tsgeo/Formatter/Coordinate/DecimalMinutes";
 
@@ -75,7 +75,7 @@
  let boatImage = "boat3.jpg";
 
  import { tankSort } from "./helpers.ts"
-
+ 
  const globalLogger = new Logger({ name: "global" });
  let globalClient: VIAM.RobotClient;
  let globalClientLastReset = new Date();
@@ -107,12 +107,12 @@
    acPowers : {},
    acPowerData : false,
    gaugesToHistorical : {},
-
+   
    allResources : [],
 
    cameraNames : [],
    lastCameraTimes : [],
-
+   
    numUpdates: 0,
    status: "Not connected yet",
    statusLastError: new Date(),
@@ -126,7 +126,7 @@
    movementSensorProps : {},
    movementSensorAlternates : [],
    movementSensorForQuery : "",
-
+   
    aisSensorName : "",
    allPgnSensorName : "",
    seatempSensorName : "",
@@ -136,10 +136,10 @@
    spotZeroSWSensorName : "",
    seakeeperSensorName : "",
    acPowers : [],
-
+   
    zoomModifier : 0,
  });
-
+ 
  let mapGlobal = $state({
 
    map: null,
@@ -150,7 +150,7 @@
    routeFeatures: new Collection(),
    trackFeaturesLastCheck : new Date(0),
    myBoatMarker: null,
-
+   
    inPanMode: false,
    lastZoom: 0,
    lastCenter: null,
@@ -158,7 +158,7 @@
    layerOptions: [],
    onLayers: new Collection(),
  });
-
+ 
  function gotNewData() {
    globalData.lastData = new Date();
  }
@@ -168,7 +168,7 @@
      return errorHandler(e, m);
    };
  }
-
+ 
  function errorHandler(e, context) {
    globalData.statusLastError = new Date();
    if (context) {
@@ -181,15 +181,15 @@
    if (context) {
      globalData.status = context + " : " + globalData.status;
    }
-
+   
    var reset = false;
-
+   
    var diff = new Date() - globalData.lastData;
-
+   
    if (diff > 1000 * 30) {
      reset = true;
    }
-
+   
    if (s.indexOf("SESSION_EXPIRED") >= 0) {
      reset = true;
    }
@@ -208,10 +208,10 @@
    mapGlobal.lastCenter = [0,0];
    mapGlobal.inPanMode = false;
  }
-
+ 
  function doUpdate(loopNumber: int, client: VIAM.RobotClient){
    const msClient = new VIAM.MovementSensorClient(client, globalConfig.movementSensorName);
-
+   
    msClient.getPosition().then((p) => {
      mapGlobal.inGetPositionHelper = true;
      gotNewData();
@@ -227,12 +227,12 @@
        var gpsFormatter = new DecimalMinutes();
        gpsFormatter.setSeparator("\n")
                    .useCardinalLetters(true);
-
+       
        globalData.posString = gpsFormatter.format(myPos);
      } else {
        globalData.posString = p.coordinate.latitude.toFixed(5) + ", " + p.coordinate.longitude.toFixed(5);
      }
-
+     
      if (mapGlobal.lastZoom > 0 && mapGlobal.lastCenter != null && mapGlobal.lastCenter[0] != 0 ) {
        var z = mapGlobal.view.getZoom();
        if (z != mapGlobal.lastZoom) {
@@ -246,10 +246,10 @@
        }
      }
 
-
+     
      var sz = mapGlobal.map.getSize();
      var pp = [globalData.pos.lng, globalData.pos.lat];
-
+     
      mapGlobal.myBoatMarker.setGeometry(new Point(pp));
 
      if (!mapGlobal.inPanMode) {
@@ -267,13 +267,13 @@
        mapGlobal.lastZoom = zoom;
        mapGlobal.lastCenter = pp;
      }
-
+     
    }).catch(errorHandlerMaker("movement sensor"));
-
+   
    msClient.getLinearVelocity().then((v) => {
      globalData.speed = msToKnots(v.y);
    }).catch(errorHandlerMaker("linear velocity"));
-
+   
    msClient.getCompassHeading().then((ch) => {
      globalData.heading = ch;
    }).catch(errorHandlerMaker("compass"));
@@ -341,10 +341,10 @@
        globalData.acPowers[n] = d;
        globalData.acPowerData = true;
      }).catch( errorHandlerMaker(acPowerName));
-
+     
    });
 
-
+   
    if (loopNumber % 30 == 2 ) {
 
      globalData.allResources.forEach( (r) => {
@@ -354,14 +354,14 @@
        if (r.name.indexOf("fuel") < 0 && r.name.indexOf("freshwater") < 0) {
          return;
        }
-
+       
        var sp = r.name.split(":");
        var name = sp[sp.length-1];
 
        new VIAM.SensorClient(client, r.name).getReadings().then((raw) => {
          globalData.gauges[name] = raw;
        }).catch( errorHandlerMaker(r.name) );
-
+       
      });
 
      if (globalConfig.allPgnSensorName != "") {
@@ -375,7 +375,7 @@
          }
        });
      }
-
+     
      if (globalConfig.aisSensorName != "") {
        new VIAM.SensorClient(client, globalConfig.aisSensorName).getReadings().then((raw) => {
          updateAISFeatures(mapGlobal.aisFeatures, raw);
@@ -385,7 +385,7 @@
 
 
  }
-
+ 
  function doCameraLoop(loopNumber: int, client: VIAM.RobotClient) {
 
    while (globalData.lastCameraTimes.length > 20){
@@ -395,15 +395,15 @@
    if (globalData.lastCameraTimes.length > 0) {
      var avg = globalData.lastCameraTimes.reduce( (a,b) => a + b) / globalData.lastCameraTimes.length;
      var mod = Math.floor((avg * 20) / 1000);
-
+     
      if (mod > 0 && loopNumber > 4 && loopNumber % mod > 0) {
        return;
      }
-
+     
    }
 
    var start = new Date();
-
+   
    filterResources(globalData.allResources, "component", "camera").forEach( (r) => {
      var cc = findComponentConfig(r.name);
      var skip = cc && cc.attributes && cc.attributes["chartplotter-hide"];
@@ -414,7 +414,7 @@
        }
        return;
      }
-
+     
      if (globalData.cameraNames.indexOf(r.name) < 0) {
        globalData.cameraNames.push(r.name);
        globalData.cameraNames.sort();
@@ -432,7 +432,7 @@
        removeCamera(r.name);
        errorHandler(e, r.name);
      });
-
+     
    });
 
  }
@@ -467,6 +467,7 @@
    globalConfig.acPowers = sensorNames.acPowers;
 
    console.log("globalConfig", $state.snapshot(globalConfig));
+
  }
 
  async function updateAndLoop() {
@@ -476,7 +477,7 @@
    if (timeSinceLastError > (120 * 1000) ) {
      globalData.status = "";
    }
-
+   
    if (!globalClient) {
      try {
        globalClient = await connect();
@@ -487,13 +488,13 @@
        globalClient = null;
      }
    } else if (globalData.numUpdates % 120 == 0) {
-     await updateResources(globalClient);
+     await updateResources(globalClient);     
    }
 
    updateOnLayers(mapGlobal.layerOptions, mapGlobal.onLayers);
-
+   
    var client = globalClient;
-
+   
    if (client) {
      doUpdate(globalData.numUpdates, client);
      doCameraLoop(globalData.numUpdates, client);
@@ -531,7 +532,7 @@
        }
      }
    }
-
+   
    const credential = {
      type: 'api-key',
      payload: apiKey,
@@ -540,7 +541,7 @@
 
    return [host, credential];
  }
-
+ 
  async function updateCloudDataAndLoop() {
    const [host, credential] = getHostAndCredentials();
 
@@ -549,14 +550,14 @@
        const opts: VIAM.ViamClientOptions = {
          credentials: credential,
        };
-
+       
        globalCloudClient = await VIAM.createViamClient(opts);
-
+       
      } catch( error ) {
        console.log("cannot connect to cloud: " + error);
      }
    }
-
+   
    if (globalCloudClient) {
      try {
        await updateMachineConfig(globalCloudClient.appClient);
@@ -577,7 +578,7 @@
    if (!part || !part.part) {
      throw new Error('Failed to get robot part: part or part.part is undefined')
    }
-
+   
    globalData.partConfig = JSON.parse(part.configJson);
  }
 
@@ -629,9 +630,10 @@
    return false;
  }
 
+
  async function updateGaugeGraphs(dc, robotName) {
    var startTime = new Date(new Date() - 86400 * 1000);
-
+   
    if (globalConfig.movementSensorName && globalData.posHistorical.length == 0) {
      // HACK HACK
      const urlParams = new URLSearchParams(window.location.search);
@@ -643,7 +645,7 @@
      } else {
        data = await positionHistoryMQL(dc, startTime, globalConfig, globalClientCloudMetaData);
      }
-
+     
      mapGlobal.trackFeatures.clear();
 
      var first = [];
@@ -666,7 +668,7 @@
        var x = [p.pos.coordinate.longitude, p.pos.coordinate.latitude];
        mapGlobal.trackFeatures.push(createTrackLine(x, first));
      }
-
+     
      mapGlobal.trackFeaturesLastCheck = new Date();
      globalData.posHistorical = data;
    }
@@ -677,21 +679,22 @@
        continue;
      }
 
+
      var timeStart = new Date();
      var data = await getDataViaMQL(dc, g, startTime, globalClientCloudMetaData);
      var getDataTime = (new Date()).getTime() - timeStart.getTime();
-
+     
      console.log("time to get graph data for " + g + " took " + getDataTime + " and had " + data.length + " points");
-
+     
      h = { ts : new Date(), data : data };
      globalData.gaugesToHistorical[g] = h;
    }
 
  }
-
+ 
  async function connect(): VIAM.RobotClient {
    const [host, credential] = getHostAndCredentials();
-
+   
    var c = await VIAM.createRobotClient({
      host,
      credentials: credential,
@@ -701,11 +704,11 @@
      reconnectMaxAttempts: 20,
      reconnectMaxWait: 5000,
    });
-
+   
    globalData.status = "Connected";
-
+   
    globalLogger.info('connected!');
-
+   
    c.on('disconnected', disconnected);
    c.on('reconnected', reconnected);
 
@@ -730,8 +733,8 @@
    try {
      setupMap();
      updateAndLoop();
-
-     return {}
+     
+     return {}     
    } catch (error) {
      errorHandler(error);
    }
@@ -744,9 +747,8 @@
      temp = parseInt(temp);
      globalConfig.zoomModifier = temp;
    }
-
    useGeographic();
-
+   
    mapGlobal.layerOptions = setupLayers(
      mapGlobal.aisFeatures,
      mapGlobal.trackFeatures,
@@ -769,17 +771,19 @@
      zoom: 15
    });
 
-   const scaleThing = new ScaleLine({
-    units: "nautical",
-    bar: true,
-    text: false,
+   var scaleThing = new ScaleLine({
+     units: "nautical",
+     bar: true,
+     text: false,
+     //minWidth: 140,
    });
 
+   
    mapGlobal.map = new Map({
-    target: 'map',
-    layers: mapGlobal.onLayers,
-    view: mapGlobal.view,
-    controls: defaultControls().extend([scaleThing])
+     target: 'map',
+     layers: mapGlobal.onLayers,
+     view: mapGlobal.view,
+     controls: defaultControls().extend([scaleThing])
    });
 
    updateOnLayers(mapGlobal.layerOptions, mapGlobal.onLayers);
@@ -799,7 +803,7 @@
    }).catch( (e) => {
      errorHandler(e);
    });
-
+   
    return true;
  }
 </script>
@@ -822,7 +826,7 @@
       {/each}
     </div>
   </div>
-
+  
   <aside class="lg:row-span-6 flex flex-col gap-4 border border-dark p-1 min-h-full text-white">
     {#if globalData.status === "Connected"}
       <div class="flex gap-2 items-center w-full min-h-12 px-2 border border-success-medium">
@@ -848,7 +852,7 @@
           <div class="min-w-32">SOG<br></div>
           <div>
             <span class="font-bold">{globalData.speed.toFixed(2)}</span>
-            <sup>knots</sup>
+            <sup>knots</sup>  
           </div>
         </div>
       {/if}
@@ -857,7 +861,7 @@
           <div class="min-w-32">Depth</div>
           <div>
             <span class="font-bold">{globalData.depth.toFixed(2)}</span>
-            <sup>ft</sup>
+            <sup>ft</sup> 
           </div>
         </div>
       {/if}
@@ -964,7 +968,7 @@
                   <LinkedLabel linked="{key}"/>
                 </div>
               </div>
-            {/if}
+            {/if}   
             </div>
           </section>
         {/each}

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -25,7 +25,6 @@
    LinkedValue
  } from "svelte-tiny-linked-charts"
 
-
  import * as VIAM from '@viamrobotics/sdk';
 
  import {
@@ -82,7 +81,7 @@
  let globalClientCloudMetaData = null;
 
  let globalCloudClient: VIAM.ViamClient;
-
+ 
  let globalData = $state({
    pos : new Coordinate(0,0),
    posHistory : [],

--- a/src/lib/chart/features.ts
+++ b/src/lib/chart/features.ts
@@ -1,0 +1,122 @@
+import Feature from 'ol/Feature.js';
+import Point from 'ol/geom/Point.js';
+import Circle from 'ol/geom/Circle.js';
+import LineString from 'ol/geom/LineString.js';
+import Collection from 'ol/Collection.js';
+
+/**
+ * Create a boat marker feature at specified coordinates
+ */
+export function createBoatMarker(coordinates: number[] = [0, 0]) {
+  return new Feature({
+    type: 'geoMarker',
+    header: 0,
+    geometry: new Point(coordinates),
+  });
+}
+
+/**
+ * Create AIS feature for vessel tracking
+ */
+export function createAISFeature(mmsi: string, boat: any) {
+  return new Feature({
+    type: "ais",
+    mmsi: mmsi,
+    heading: boat.Heading,
+    geometry: new Point([boat.Location[1], boat.Location[0]]),
+  });
+}
+
+/**
+ * Create track point feature
+ */
+export function createTrackPoint(coordinates: number[]) {
+  return new Feature({
+    type: "track",
+    geometry: new Circle(coordinates)
+  });
+}
+
+/**
+ * Create track line feature connecting two points
+ */
+export function createTrackLine(startCoords: number[], endCoords: number[]) {
+  return new Feature({
+    type: "track",
+    geometry: new LineString([startCoords, endCoords])
+  });
+}
+
+/**
+ * Process NMEA 2000 PGN 129285
+ * Clears existing route features and creates new ones from waypoint list
+ */
+export function processRoute129285(doc: any, routeFeatures: Collection<Feature>) {
+  console.log(doc);
+  
+  routeFeatures.clear();
+
+  if (!doc.list) {
+    return;
+  }
+  
+  let prev: number[] = [];
+  
+  for (let x = 0; x < doc.list.length; x++) {
+    const wp = doc.list[x];
+    const loc = [wp["WP Longitude"], wp["WP Latitude"]];
+    if (prev.length > 0) {
+      const f = new Feature({
+        type: "track",
+        geometry: new LineString([prev, loc]),
+      });
+      routeFeatures.push(f);
+    }
+    prev = loc;
+  }
+  
+  console.log(routeFeatures);
+}
+
+/**
+ * Update AIS features collection with new vessel data
+ * Removes stale vessels and updates/adds current ones
+ */
+export function updateAISFeatures(aisFeatures: Collection<Feature>, rawAISData: any) {
+  const good: Record<string, boolean> = {};
+  
+  for (const mmsi in rawAISData) {
+    const boat = rawAISData[mmsi];
+    
+    if (boat == null || boat.Location == null || boat.Location.length != 2 || boat.Location[0] == null) {
+      continue;
+    }
+    
+    good[mmsi] = true;
+    
+    let found = false;
+    
+    for (let i = 0; i < aisFeatures.getLength(); i++) {
+      const v = aisFeatures.item(i);
+      if (v.get("mmsi") == mmsi) {
+        found = true;
+        v.setGeometry(new Point([boat.Location[1], boat.Location[0]]));
+        break;
+      }
+    }
+    
+    if (!found) {
+      aisFeatures.push(createAISFeature(mmsi, boat));
+    }
+  }
+  
+  // Remove stale AIS features
+  for (let i = 0; i < aisFeatures.getLength(); i++) {
+    const v = aisFeatures.item(i);
+    const mmsi = v.get("mmsi");
+    if (!good[mmsi]) {
+      aisFeatures.removeAt(i);
+      i--; // Adjust index after removal
+    }
+  }
+}

--- a/src/lib/chart/layers.ts
+++ b/src/lib/chart/layers.ts
@@ -1,0 +1,86 @@
+import TileLayer from 'ol/layer/Tile';
+import TileWMS from 'ol/source/TileWMS.js';
+import XYZ from 'ol/source/XYZ';
+
+/**
+ * Custom tile URL function (for seamark tiles)
+ * Handles coordinate wrapping and URL selection
+ */
+export function getTileUrlFunction(url: string | string[], type: string, coordinates: number[]) {
+  const x = coordinates[1];
+  let y = coordinates[2];
+  const z = coordinates[0];
+  const limit = Math.pow(2, z);
+  if (y < 0 || y >= limit) {
+    return null;
+  } else {
+    const wrappedX = ((x % limit) + limit) % limit;
+    
+    const path = z + "/" + wrappedX + "/" + y + "." + type;
+    if (url instanceof Array) {
+      url = url[0];
+    }
+    return url + path;
+  }
+}
+
+/**
+ * Create OpenStreetMap tile layer
+ */
+export function createOSMLayer() {
+  return new TileLayer({
+    opacity: .5,
+    source: new XYZ({
+      url: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png'
+    })
+  });
+}
+
+/**
+ * Create depth/bathymetry layer from OpenSeaMap
+ */
+export function createDepthLayer() {
+  return new TileLayer({
+    opacity: .7,
+    source: new TileWMS({
+      url: 'https://geoserver.openseamap.org/geoserver/gwc/service/wms',
+      params: {'LAYERS': 'gebco2021:gebco_2021', 'VERSION':'1.1.1'},
+      ratio: 1,
+      serverType: 'geoserver',
+      hidpi: false,
+    }),
+  });
+}
+
+/**
+ * Create seamark layer from OpenSeaMap
+ */
+export function createSeamarkLayer() {
+  return new TileLayer({
+    visible: true,
+    maxZoom: 19,
+    source: new XYZ({
+      tileUrlFunction: function(coordinate) {
+        return getTileUrlFunction("https://tiles.openseamap.org/seamark/", 'png', coordinate);
+      }
+    }),
+    properties: {
+      name: "seamarks",
+      layerId: 3,
+      cookieKey: "SeamarkLayerVisible",
+      checkboxId: "checkLayerSeamark",
+    }
+  });
+}
+
+/**
+ * Create NOAA chart layer
+ */
+export function createNOAALayer() {
+  return new TileLayer({
+    opacity: .7,
+    source: new TileWMS({
+      url: "https://gis.charttools.noaa.gov/arcgis/rest/services/MCS/NOAAChartDisplay/MapServer/exts/MaritimeChartService/WMSServer",
+    }),
+  });
+}

--- a/src/lib/chart/layers.ts
+++ b/src/lib/chart/layers.ts
@@ -45,7 +45,6 @@ export function createDepthLayer() {
     source: new TileWMS({
       url: 'https://geoserver.openseamap.org/geoserver/gwc/service/wms',
       params: {'LAYERS': 'gebco2021:gebco_2021', 'VERSION':'1.1.1'},
-      ratio: 1,
       serverType: 'geoserver',
       hidpi: false,
     }),
@@ -81,6 +80,7 @@ export function createNOAALayer() {
     opacity: .7,
     source: new TileWMS({
       url: "https://gis.charttools.noaa.gov/arcgis/rest/services/MCS/NOAAChartDisplay/MapServer/exts/MaritimeChartService/WMSServer",
+      params: {}
     }),
   });
 }

--- a/src/lib/chart/setup.ts
+++ b/src/lib/chart/setup.ts
@@ -1,0 +1,230 @@
+import Map from 'ol/Map';
+import View from 'ol/View';
+import Collection from 'ol/Collection.js';
+import VectorSource from 'ol/source/Vector.js';
+import { Vector, Tile } from 'ol/layer.js';
+import { Icon, Style } from 'ol/style.js';
+import { Fill, Stroke } from 'ol/style.js';
+
+import { 
+  createOSMLayer, 
+  createDepthLayer, 
+  createSeamarkLayer, 
+  createNOAALayer 
+} from './layers.js';
+import { createBoatMarker } from './features.js';
+
+export interface LayerOption {
+  name: string;
+  on: boolean;
+  layer: any;
+}
+
+export interface MapGlobal {
+  map: Map | null;
+  view: View | null;
+  aisFeatures: Collection<any>;
+  trackFeatures: Collection<any>;
+  routeFeatures: Collection<any>;
+  trackFeaturesLastCheck: Date;
+  myBoatMarker: any;
+  inPanMode: boolean;
+  lastZoom: number;
+  lastCenter: number[] | null;
+  layerOptions: LayerOption[];
+  onLayers: Collection<any>;
+}
+
+/**
+ * Setup all layer options with their configurations
+ */
+export function setupLayers(
+  aisFeatures: Collection<any>,
+  trackFeatures: Collection<any>, 
+  routeFeatures: Collection<any>,
+  boatImage: string,
+  getGlobalDataHeading: () => number
+): LayerOption[] {
+  const layerOptions: LayerOption[] = [];
+
+  // Core open street maps
+  layerOptions.push({
+    name: "open street map",
+    on: false,
+    layer: createOSMLayer(),
+  });
+  
+  // Depth data
+  layerOptions.push({
+    name: "depth",
+    on: false,
+    layer: createDepthLayer(),
+  });
+  
+  // Harbors/seamarks
+  layerOptions.push({
+    name: "seamark",
+    on: false,
+    layer: createSeamarkLayer(),
+  });
+  
+  // NOAA charts
+  layerOptions.push({
+    name: "noaa",
+    on: true,
+    layer: createNOAALayer(),
+  });
+
+  // Boat marker layer
+  const myBoatMarker = createBoatMarker();
+  const myBoatFeatures = new Collection();
+  myBoatFeatures.push(myBoatMarker);
+  
+  const myBoatLayer = new Vector({
+    source: new VectorSource({
+      features: myBoatFeatures,
+    }),
+    style: function (feature) {
+      const scale = 0.6;
+      const rotation = (getGlobalDataHeading() / 360) * Math.PI * 2;
+      
+      return new Style({
+        image: new Icon({
+          src: boatImage,
+          scale: scale,
+          rotation: rotation,
+        }),
+      });
+    },
+  });
+  
+  layerOptions.push({
+    name: "boat",
+    on: true,
+    layer: myBoatLayer,
+  });
+
+  // AIS layer
+  const aisLayer = new Vector({
+    source: new VectorSource({
+      features: aisFeatures,
+    }),
+    style: function (feature) {
+      const scale = 0.25;
+      let rotation = 0;
+      
+      const h = feature.get("heading");
+      if (h >= 0 && h < 360) {
+        rotation = (h / 360) * Math.PI * 2;
+      }
+      
+      return new Style({
+        image: new Icon({
+          src: boatImage,
+          scale: scale,
+          rotation: rotation,
+        }),
+      });
+    },
+  });
+
+  layerOptions.push({
+    name: "ais",
+    on: true,
+    layer: aisLayer,
+  });
+
+  // Track layer
+  const trackLayer = new Vector({
+    source: new VectorSource({
+      features: trackFeatures,
+    }),
+    style: new Style({
+      stroke: new Stroke({
+        color: "blue",
+        width: 3
+      }),
+      fill: new Fill({
+        color: "rgba(0, 255, 0, 0.1)"
+      })
+    }),
+  });
+
+  layerOptions.push({
+    name: "track",
+    on: true,
+    layer: trackLayer,
+  });
+  
+  // Route layer
+  const routeLayer = new Vector({
+    source: new VectorSource({
+      features: routeFeatures,
+    }),
+    style: new Style({
+      stroke: new Stroke({
+        color: "green",
+        width: 3
+      }),
+      fill: new Fill({
+        color: "rgba(0, 255, 0, 0.1)"
+      })
+    }),
+  });
+
+  layerOptions.push({
+    name: "route",
+    on: true,
+    layer: routeLayer,
+  });
+
+  return layerOptions;
+}
+
+/**
+ * Find layer option by name
+ */
+export function findLayerByName(layerOptions: LayerOption[], name: string): LayerOption | null {
+  for (const l of layerOptions) {
+    if (l.name === name) {
+      return l;
+    }
+  }
+  return null;
+}
+
+/**
+ * Find index of layer in onLayers collection by name
+ */
+export function findOnLayerIndexOfName(layerOptions: LayerOption[], onLayers: Collection<any>, name: string): number {
+  const l = findLayerByName(layerOptions, name);
+  if (l == null) {
+    return -2;
+  }
+
+  for (let i = 0; i < onLayers.getLength(); i++) {
+    if (onLayers.item(i).ol_uid == l.layer.ol_uid) {
+      return i;
+    }
+  }
+  return -1;
+}
+
+/**
+ * Update onLayers collection based on layer options
+ */
+export function updateOnLayers(layerOptions: LayerOption[], onLayers: Collection<any>) {
+  for (const l of layerOptions) {
+    const idx = findOnLayerIndexOfName(layerOptions, onLayers, l.name);
+
+    if (l.on) {
+      if (idx < 0) {
+        onLayers.push(l.layer);
+      }
+    } else {
+      if (idx >= 0) {
+        onLayers.removeAt(idx);
+      }
+    }
+  }
+}

--- a/src/lib/chart/setup.ts
+++ b/src/lib/chart/setup.ts
@@ -1,6 +1,7 @@
 import Map from 'ol/Map';
 import View from 'ol/View';
 import Collection from 'ol/Collection.js';
+import Feature from 'ol/Feature';
 import VectorSource from 'ol/source/Vector.js';
 import { Vector, Tile } from 'ol/layer.js';
 import { Icon, Style } from 'ol/style.js';
@@ -77,7 +78,7 @@ export function setupLayers(
 
   // Boat marker layer
   const myBoatMarker = createBoatMarker();
-  const myBoatFeatures = new Collection();
+  const myBoatFeatures = new Collection<Feature>();
   myBoatFeatures.push(myBoatMarker);
   
   const myBoatLayer = new Vector({

--- a/src/lib/data/queries.ts
+++ b/src/lib/data/queries.ts
@@ -1,0 +1,115 @@
+import { BSON } from "bsonfy";
+
+/**
+ * Get gauge data via MQL query
+ * Retrieves historical gauge readings aggregated in 15-minute buckets
+ */
+export async function getDataViaMQL(dc: any, g: string, startTime: Date, cloudMetaData: any) {
+  const match = {
+    "location_id": cloudMetaData.locationId,
+    "robot_id": cloudMetaData.machineId,
+    "component_name": g,
+    time_received: { $gte: startTime }
+  };
+  
+  const group = {
+    "_id": { 
+      "$concat": [
+        { "$toString": { "$substr": [{ "$year": "$time_received" }, 2, -1] } },
+        "-",
+        { "$toString": { "$month": "$time_received" } },
+        "-",
+        { "$toString": { "$dayOfMonth": "$time_received" } },
+        " ",
+        { "$toString": { "$hour": "$time_received" } },
+        ":",
+        { "$toString": { "$multiply": [15, { "$floor": { "$divide": [{ "$minute": "$time_received" }, 15] } }] } }
+      ]
+    },
+    "ts": { "$min": "$time_received" },
+    "min": { "$min": "$data.readings.Level" },
+    "max": { "$max": "$data.readings.Level" }
+  };
+  
+  const query = [
+    BSON.serialize({ "$match": match }),
+    BSON.serialize({ "$group": group }),
+    BSON.serialize({ "$sort": { ts: -1 } }),
+    BSON.serialize({ "$limit": (24 * 4) }),
+    BSON.serialize({ "$sort": { ts: 1 } }),
+  ];
+
+  const data = await dc.tabularDataByMQL(cloudMetaData.primaryOrgId, query, true);
+  return data;
+}
+
+/**
+ * Get position history via MQL query
+ * Tries configured sensor first, then falls back to alternatives
+ */
+export async function positionHistoryMQL(dc: any, startTime: Date, globalConfig: any, cloudMetaData: any) {
+  if (globalConfig.movementSensorForQuery !== "") {
+    const res = await positionHistoryMQLNamed(dc, startTime, globalConfig.movementSensorForQuery, cloudMetaData, false);
+    if (res.length > 0) {
+      return res;
+    }
+  }
+  
+  for (let i = 0; i < globalConfig.movementSensorAlternates.length; i++) {
+    const n = globalConfig.movementSensorAlternates[i];
+    
+    const res = await positionHistoryMQLNamed(dc, startTime, n, cloudMetaData, false);
+    if (res.length > 0) {
+      globalConfig.movementSensorForQuery = n;
+      return res;
+    }
+  }
+  return [];
+}
+
+/**
+ * Get position history for a specific movement sensor
+ * Queries position data aggregated by minute
+ */
+export async function positionHistoryMQLNamed(dc: any, startTime: Date, sensorName: string, cloudMetaData: any, hot: boolean) {
+  const name = sensorName.split(":");
+  
+  const match = {
+    "location_id": cloudMetaData.locationId,
+    "robot_id": cloudMetaData.machineId,
+    "component_name": name[name.length - 1],
+    "method_name": "Position",
+    "time_received": { $gte: startTime }
+  };
+  
+  const group = {
+    "_id": { 
+      "$concat": [
+        { "$toString": { "$substr": [{ "$year": "$time_received" }, 2, -1] } },
+        "-",
+        { "$toString": { "$month": "$time_received" } },
+        "-",
+        { "$toString": { "$dayOfMonth": "$time_received" } },
+        " ",
+        { "$toString": { "$hour": "$time_received" } },
+        ":",
+        { "$toString": { "$minute": "$time_received" } },
+      ]
+    },
+    "ts": { "$min": "$time_received" },
+    "pos": { "$first": "$data" },
+  };
+  
+  const query = [
+    BSON.serialize({ "$match": match }),
+    BSON.serialize({ "$sort": { ts: -1 } }),
+    BSON.serialize({ "$group": group }),
+    BSON.serialize({ "$sort": { ts: -1 } }),
+  ];
+
+  const timeStart = new Date();
+  const data = await dc.tabularDataByMQL(cloudMetaData.primaryOrgId, query, hot);
+  const getDataTime = (new Date()).getTime() - timeStart.getTime();
+  console.log("got " + data.length + " history data points from:" + sensorName + " in " + getDataTime + "ms");
+  return data;
+}

--- a/src/lib/data/sensors.ts
+++ b/src/lib/data/sensors.ts
@@ -1,0 +1,114 @@
+import * as VIAM from '@viamrobotics/sdk';
+
+/**
+ * Filter resources by type, subtype, and optional name pattern
+ * Returns matching resources from the provided list
+ */
+export function filterResources(resources: any[], type: string, subtype: string, namePattern: RegExp | null = null) {
+  const filtered = [];
+  for (const resource of resources) {
+    if (type !== "" && resource.type !== type) {
+      continue;
+    }
+
+    if (subtype !== "" && resource.subtype !== subtype) {
+      continue;
+    }
+
+    if (namePattern != null && !resource.name.match(namePattern)) {
+      continue;
+    }
+
+    filtered.push(resource);
+  }
+
+  return filtered;
+}
+
+/**
+ * Filter resources and return the first matching name
+ * Returns empty string if no matches found
+ */
+export function filterResourcesFirstMatchingName(resources: any[], type: string, subtype: string, namePattern: RegExp | null = null): string {
+  const matching = filterResources(resources, type, subtype, namePattern);
+  if (matching.length > 0) {
+    return matching[0].name;
+  }
+  return "";
+}
+
+/**
+ * Filter resources and return all matching names sorted
+ * Returns array of resource names
+ */
+export function filterResourcesAllMatchingNames(resources: any[], type: string, subtype: string, namePattern: RegExp | null = null): string[] {
+  const matching = filterResources(resources, type, subtype, namePattern);
+  const names = [];
+  for (const resource of matching) {
+    names.push(resource.name);
+  }
+  return names.sort();
+}
+
+/**
+ * Setup movement sensor by finding the best available sensor
+ * Prioritizes sensors with more capabilities (position, velocity, compass)
+ */
+export async function setupMovementSensor(client: VIAM.RobotClient, resources: any[]) {
+  const movementSensors = filterResources(resources, "component", "movement_sensor", null);
+
+  const allGpsNames = [];
+  
+  // Pick best movement sensor
+  let bestName = "";
+  let bestScore = 0;
+  let bestProp = {};
+  
+  for (const resource of movementSensors) {
+    const msClient = new VIAM.MovementSensorClient(client, resource.name);
+    const prop = await msClient.getProperties();
+
+    let score = 0;
+    if (prop.positionSupported) {
+      allGpsNames.push(resource.name);
+      score++;
+    }
+    if (prop.linearVelocitySupported) {
+      score++;
+    }
+    if (prop.compassHeadingSupported) {
+      score++;
+    }
+
+    // Prefer higher scores, tie-break with shorter names
+    if (score > bestScore || (score === bestScore && resource.name.length < bestName.length)) {
+      bestName = resource.name;
+      bestScore = score;
+      bestProp = prop;
+    }
+  }
+  
+  return {
+    movementSensorName: bestName,
+    movementSensorProps: bestProp,
+    movementSensorAlternates: allGpsNames
+  };
+}
+
+/**
+ * Discover and configure all sensor names from resources
+ * Returns configuration object with sensor names for different types
+ */
+export function discoverSensorNames(resources: any[]) {
+  return {
+    aisSensorName: filterResourcesFirstMatchingName(resources, "component", "sensor", /\bais$/),
+    allPgnSensorName: filterResourcesFirstMatchingName(resources, "component", "sensor", /\ball.pgn$/),
+    seatempSensorName: filterResourcesFirstMatchingName(resources, "component", "sensor", /\bseatemp$/),
+    depthSensorName: filterResourcesFirstMatchingName(resources, "component", "sensor", /depth/),
+    windSensorName: filterResourcesFirstMatchingName(resources, "component", "sensor", /wind/),
+    spotZeroFWSensorName: filterResourcesFirstMatchingName(resources, "component", "sensor", /spotzero-fw/),
+    spotZeroSWSensorName: filterResourcesFirstMatchingName(resources, "component", "sensor", /spotzero-sw/),
+    seakeeperSensorName: filterResourcesFirstMatchingName(resources, "component", "sensor", /seakeeper/),
+    acPowers: filterResourcesAllMatchingNames(resources, "component", "sensor", /\bac-\d-\d$/)
+  };
+}

--- a/src/lib/utils/conversions.ts
+++ b/src/lib/utils/conversions.ts
@@ -1,0 +1,99 @@
+/**
+ * Convert meters per second to knots
+ * Used for displaying boat speed in nautical units
+ */
+export function msToKnots(speedMs: number): number {
+  return speedMs * 1.94384;
+}
+
+/**
+ * Calculate point difference for pan detection
+ * Used to detect when user is manually panning the map
+ */
+export function pointDiff(x: number[], y: number[]): number {
+  const a = x[0] - y[0];
+  const b = x[1] - y[1];
+  const c = a * a + b * b;
+  return Math.sqrt(c);
+}
+
+/**
+ * Convert Celsius to Fahrenheit
+ * Used for water temperature display
+ */
+export function celsiusToFahrenheit(celsius: number): number {
+  return 32 + (celsius * 1.8);
+}
+
+/**
+ * Convert liters to gallons  
+ * Used for fuel and water tank displays
+ */
+export function litersToGallons(liters: number): number {
+  return liters * 0.264172;
+}
+
+/**
+ * Calculate total fuel level across multiple tanks
+ * Returns total fuel in gallons
+ */
+export function fuelTotalLevel(gauges: Record<string, any>): number {
+  let total = 0;
+  for (const k in gauges) {
+    const g = gauges[k];
+    if (g["Type"] !== "Fuel") {
+      continue;
+    }
+    total += g["Level"] * g["Capacity"] / 100;
+  }
+  return Math.round(total * 0.264172);
+}
+
+/**
+ * Calculate total fuel capacity across multiple tanks
+ * Returns total capacity in gallons
+ */
+export function fuelTotalCapacity(gauges: Record<string, any>): number {
+  let total = 0;
+  for (const k in gauges) {
+    const g = gauges[k];
+    if (g["Type"] !== "Fuel") {
+      continue;
+    }
+    total += g["Capacity"];
+  }
+  return Math.round(total * 0.264172);
+}
+
+/**
+ * Calculate average AC power voltage
+ */
+export function acPowerVoltAverage(data: Record<string, any>): number {
+  let total = 0;
+  let num = 0;
+  
+  for (const k in data) {
+    const dd = data[k];
+    total += dd["Line-Neutral AC RMS Voltage"];
+    num++;
+  }
+  
+  return total / num;
+}
+
+/**
+ * Calculate total AC power amperage at specified voltage
+ */
+export function acPowerAmpAt(vvv: number, data: Record<string, any>): number {
+  let total = 0;
+  
+  for (const k in data) {
+    const dd = data[k];
+    const a = dd["AC RMS Current"];
+    const v = dd["Line-Neutral AC RMS Voltage"];
+    const w = a * v;
+    total += w / vvv;
+  }
+  
+  return total;
+}

--- a/src/lib/utils/helpers.ts
+++ b/src/lib/utils/helpers.ts
@@ -1,0 +1,50 @@
+/**
+ * Convert dictionary to sorted array of key-value pairs
+ * Used for rendering gauge data in sorted order
+ */
+export function dicToArray(d: Record<string, any>, sortFunction?: (names: string[]) => string[]): [string, any][] {
+  let names = Object.keys(d);
+  if (sortFunction) {
+    names = sortFunction(names);
+  } else {
+    names.sort();
+  }
+
+  const a: [string, any][] = [];
+  
+  for (let i = 0; i < names.length; i++) {
+    const n = names[i];
+    a.push([n, d[n]]);
+  }
+  return a;
+}
+
+/**
+ * Check if there's more than one fuel tank
+ * Used to determine whether to show total fuel display
+ */
+export function moreThanOneFuelTank(gauges: Record<string, any>): boolean {
+  let found = false;
+  for (const k in gauges) {
+    const g = gauges[k];
+    if (g["Type"] === "Fuel") {
+      if (found) {
+        return true;
+      }
+      found = true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Convert gauge historical data to format expected by LinkedChart
+ */
+export function gauageHistoricalToLinkedChart(data: any): Record<string, number> {
+  const res: Record<string, number> = {};
+  for (const d in data.data) {
+    const dd = data.data[d];
+    res[dd._id] = Math.floor(dd.min);
+  }
+  return res;
+}

--- a/tsconfig.lib.json
+++ b/tsconfig.lib.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./lib",
+    "declaration": true,
+    "rootDir": "./src/lib",
+    "target": "ES2020",
+    "lib": ["ES2020", "DOM"],
+    "moduleResolution": "node",
+    "skipLibCheck": true
+  },
+  "include": ["src/lib/**/*"]
+}


### PR DESCRIPTION
This PR extracts reusable chart utilities from App.svelte into modules under src/lib/ to use in other apps:

Chart utilities (`/lib/chart/`):
  * `setup.ts` - setupLayers, findLayerByName, findOnLayerIndexOfName, updateOnLayers
  * `layers.ts` - getTileUrlFunction, createOSMLayer, createDepthLayer, createSeamarkLayer, createNOAALayer
  * `features.ts` - createBoatMarker, createAISFeature, createTrackPoint, createTrackLine, processRoute129285, updateAISFeatures

Data utilities (`/lib/data/`):
  * `queries.ts` - getDataViaMQL, positionHistoryMQL, positionHistoryMQLNamed, 
  * `sensors.ts` - filterResources, filterResourcesFirstMatchingName, filterResourcesAllMatchingNames, setupMovementSensor, discoverSensorNames,

Conversion and helper utilities (`/lib/utils/`):
  * `conversions.ts` - msToKnots, pointDiff, celsiusToFahrenheit, litersToGallons, fuelTotalLevel, fuelTotalCapacity, acPowerVoltAverage, acPowerAmpAt
  * `helpers.ts` - dicToArray, moreThanOneFuelTank, gauageHistoricalToLinkedChart

Changes:
* Add package.json exports for cross-repo usage
* No functional changes to viam-chartplotter app