### PR TITLE
Update to OpenLayers 10.7, fix layer ordering and Svelte 5 compat

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
 				"@viamrobotics/sdk": "^0.52.2",
 				"@zag-js/dialog": "^1.26.3",
 				"bsonfy": "^1.0.2",
-				"ol": "^8.2.0",
+				"ol": "^10.7.0",
 				"svelte-tiny-linked-charts": "^1.6.0",
 				"tailwind-merge": "^3.3.1",
 				"tsgeo": "^1.2.2",
@@ -1237,6 +1237,12 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/@types/rbush": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@types/rbush/-/rbush-4.0.0.tgz",
+			"integrity": "sha512-+N+2H39P8X+Hy1I5mC6awlTX54k3FhiUmvt7HWzGJZvF+syUAAxP/stwppS8JE84YHqFgRMv6fCy31202CMFxQ==",
+			"license": "MIT"
+		},
 		"node_modules/@types/semver": {
 			"version": "7.7.1",
 			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.7.1.tgz",
@@ -2282,40 +2288,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/color-parse": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/color-parse/-/color-parse-2.0.2.tgz",
-			"integrity": "sha512-eCtOz5w5ttWIUcaKLiktF+DxZO1R9KLNY/xhbV6CkhM7sR3GhVghmt6X6yOnzeaM24po+Z9/S1apbXMwA3Iepw==",
-			"license": "MIT",
-			"dependencies": {
-				"color-name": "^2.0.0"
-			}
-		},
-		"node_modules/color-parse/node_modules/color-name": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/color-name/-/color-name-2.0.2.tgz",
-			"integrity": "sha512-9vEt7gE16EW7Eu7pvZnR0abW9z6ufzhXxGXZEVU9IqPdlsUiMwJeJfRtq0zePUmnbHGT9zajca7mX8zgoayo4A==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=12.20"
-			}
-		},
-		"node_modules/color-rgba": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/color-rgba/-/color-rgba-3.0.0.tgz",
-			"integrity": "sha512-PPwZYkEY3M2THEHHV6Y95sGUie77S7X8v+h1r6LSAPF3/LL2xJ8duUXSrkic31Nzc4odPwHgUbiX/XuTYzQHQg==",
-			"license": "MIT",
-			"dependencies": {
-				"color-parse": "^2.0.0",
-				"color-space": "^2.0.0"
-			}
-		},
-		"node_modules/color-space": {
-			"version": "2.3.2",
-			"resolved": "https://registry.npmjs.org/color-space/-/color-space-2.3.2.tgz",
-			"integrity": "sha512-BcKnbOEsOarCwyoLstcoEztwT0IJxqqQkNwDuA3a65sICvvHL2yoeV13psoDFh5IuiOMnIOKdQDwB4Mk3BypiA==",
-			"license": "Unlicense"
-		},
 		"node_modules/commander": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
@@ -2546,9 +2518,9 @@
 			}
 		},
 		"node_modules/earcut": {
-			"version": "2.2.4",
-			"resolved": "https://registry.npmjs.org/earcut/-/earcut-2.2.4.tgz",
-			"integrity": "sha512-/pjZsA1b4RPHbeWZQn66SWS8nZZWLQQ23oE3Eam7aroEFGEvwKAsJfZ9ytiEMycfzXWpca4FA9QIOehf7PocBQ==",
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/earcut/-/earcut-3.0.2.tgz",
+			"integrity": "sha512-X7hshQbLyMJ/3RPhyObLARM2sNxxmRALLKx1+NVFFnQ9gKzmCrxm9+uLIAdBcvc8FNLpctqlQ2V6AE92Ol9UDQ==",
 			"license": "ISC"
 		},
 		"node_modules/eastasianwidth": {
@@ -3600,26 +3572,6 @@
 			"integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
 			"dev": true,
 			"license": "ISC"
-		},
-		"node_modules/ieee754": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-			"integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			],
-			"license": "BSD-3-Clause"
 		},
 		"node_modules/ignore": {
 			"version": "5.3.2",
@@ -4791,17 +4743,16 @@
 			}
 		},
 		"node_modules/ol": {
-			"version": "8.2.0",
-			"resolved": "https://registry.npmjs.org/ol/-/ol-8.2.0.tgz",
-			"integrity": "sha512-/m1ddd7Jsp4Kbg+l7+ozR5aKHAZNQOBAoNZ5pM9Jvh4Etkf0WGkXr9qXd7PnhmwiC1Hnc2Toz9XjCzBBvexfXw==",
+			"version": "10.7.0",
+			"resolved": "https://registry.npmjs.org/ol/-/ol-10.7.0.tgz",
+			"integrity": "sha512-122U5gamPqNgLpLOkogFJhgpywvd/5en2kETIDW+Ubfi9lPnZ0G9HWRdG+CX0oP8od2d6u6ky3eewIYYlrVczw==",
 			"license": "BSD-2-Clause",
 			"dependencies": {
-				"color-rgba": "^3.0.0",
-				"color-space": "^2.0.1",
-				"earcut": "^2.2.3",
-				"geotiff": "^2.0.7",
-				"pbf": "3.2.1",
-				"rbush": "^3.0.1"
+				"@types/rbush": "4.0.0",
+				"earcut": "^3.0.0",
+				"geotiff": "^2.1.3",
+				"pbf": "4.0.1",
+				"rbush": "^4.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -4997,12 +4948,11 @@
 			}
 		},
 		"node_modules/pbf": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/pbf/-/pbf-3.2.1.tgz",
-			"integrity": "sha512-ClrV7pNOn7rtmoQVF4TS1vyU0WhYRnP92fzbfF75jAIwpnzdJXf8iTd4CMEqO4yUenH6NDqLiwjqlh6QgZzgLQ==",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/pbf/-/pbf-4.0.1.tgz",
+			"integrity": "sha512-SuLdBvS42z33m8ejRbInMapQe8n0D3vN/Xd5fmWM3tufNgRQFBpaW2YVJxQZV4iPNqb0vEFvssMEo5w9c6BTIA==",
 			"license": "BSD-3-Clause",
 			"dependencies": {
-				"ieee754": "^1.1.12",
 				"resolve-protobuf-schema": "^2.1.0"
 			},
 			"bin": {
@@ -5352,18 +5302,18 @@
 			}
 		},
 		"node_modules/quickselect": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/quickselect/-/quickselect-2.0.0.tgz",
-			"integrity": "sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/quickselect/-/quickselect-3.0.0.tgz",
+			"integrity": "sha512-XdjUArbK4Bm5fLLvlm5KpTFOiOThgfWWI4axAZDWg4E/0mKdZyI9tNEfds27qCi1ze/vwTR16kvmmGhRra3c2g==",
 			"license": "ISC"
 		},
 		"node_modules/rbush": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/rbush/-/rbush-3.0.1.tgz",
-			"integrity": "sha512-XRaVO0YecOpEuIvbhbpTrZgoiI6xBlz6hnlr6EHhd+0x9ase6EmeN+hdwwUaJvLcsFFQ8iWVF1GAK1yB0BWi0w==",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/rbush/-/rbush-4.0.1.tgz",
+			"integrity": "sha512-IP0UpfeWQujYC8Jg162rMNc01Rf0gWMMAb2Uxus/Q0qOFw4lCcq6ZnQEZwUoJqWyUGJ9th7JjwI4yIWo+uvoAQ==",
 			"license": "MIT",
 			"dependencies": {
-				"quickselect": "^2.0.0"
+				"quickselect": "^3.0.0"
 			}
 		},
 		"node_modules/read-cache": {
@@ -6278,6 +6228,21 @@
 				"picomatch": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/svelte-check/node_modules/picomatch": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
 			}
 		},
 		"node_modules/svelte-eslint-parser": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "viam-chartplotter",
-	"version": "0.0.1",
+	"version": "0.0.2",
 	"private": true,
 	"scripts": {
 		"dev": "npm-run-all --parallel dev:*",
@@ -39,7 +39,7 @@
 		"@viamrobotics/sdk": "^0.52.2",
 		"@zag-js/dialog": "^1.26.3",
 		"bsonfy": "^1.0.2",
-		"ol": "^8.2.0",
+		"ol": "^10.7.0",
 		"svelte-tiny-linked-charts": "^1.6.0",
 		"tailwind-merge": "^3.3.1",
 		"tsgeo": "^1.2.2",

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1095,14 +1095,14 @@ import type { BoatInfo } from './lib/BoatInfo';
           <div>
             <span class="font-bold">
               {#if globalData.seakeeperData["power_enabled"] >= 1}
-                <button on:click={() => seakeeper('power',false)}>P</button>
+                <button onclick={() => seakeeper('power',false)}>P</button>
               {:else if globalData.seakeeperData["power_available"] >= 1 }
-                <button on:click={() => seakeeper('power', true)}>p</button>
+                <button onclick={() => seakeeper('power', true)}>p</button>
               {/if}
               {#if globalData.seakeeperData["stabilize_enabled"] >= 1}
-                <button on:click={() => seakeeper('enable',false)}>E</button>
+                <button onclick={() => seakeeper('enable',false)}>E</button>
               {:else if globalData.seakeeperData["stabilize_available"] >= 1 }
-                <button on:click={() => seakeeper('enable',true)}>e</button>
+                <button onclick={() => seakeeper('enable',true)}>e</button>
               {/if}
               {@html globalData.seakeeperData["progress_bar_percentage"].toFixed(2)}%
               ({globalData.seakeeperData["flywheel_speed"]})
@@ -1129,9 +1129,9 @@ import type { BoatInfo } from './lib/BoatInfo';
                     width="100"
                     type="line"
                     lineColor="#0000ff"
-                    scaleMax=100
-                    linked="{key}"
-                    uid="{key}"
+                    scaleMax={100}
+                    linked={key}
+                    uid={key}
                     barMinWidth="1"
                     grow
                   />
@@ -1139,8 +1139,8 @@ import type { BoatInfo } from './lib/BoatInfo';
                 <div
                   class="hidden peer-hover:block z-10 text-nowrap -bottom-8 right-1 absolute border border-medium px-2 w-fit"
                 >
-                  <LinkedValue uid="{key}" />
-                  <LinkedLabel linked="{key}"/>
+                  <LinkedValue uid={key} />
+                  <LinkedLabel linked={key}/>
                 </div>
               </div>
             {/if}   

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,1 +1,2 @@
 // place files you want to import through the `$lib` alias in this folder.
+export type { BoatInfo } from './BoatInfo';


### PR DESCRIPTION
- Upgrade OpenLayers from 8.2.0 to 10.7.0 to align with kongsberg-apps
- Fix layer z-ordering: tile layers now render below vector layers (boat, ais)
- Export BoatInfo type from lib/index.ts for external consumers
- Replace Tailwind utility class with semantic .layer-controls class
- Fix maxZom typo -> maxZoom in seamark layer
- Remove invalid 'ratio' option from TileWMS (not supported in OL 10)
- Fix Svelte 5 deprecations: on:click -> onclick, remove quoted attributes
- Bump version to 0.0.2