### PR TITLE
Fix boats panel checkbox reactivity in MarineMap

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "viam-chartplotter",
-	"version": "0.0.4",
+	"version": "0.0.5",
 	"private": true,
 	"scripts": {
 		"dev": "npm-run-all --parallel dev:*",

--- a/src/marineMap.svelte
+++ b/src/marineMap.svelte
@@ -72,6 +72,7 @@ import type { BoatInfo } from './lib/BoatInfo';
        }
      });
      lastBoatsLength = currentLength;
+     visibleBoats = new Set(visibleBoats); // Trigger reactivity
    }
  });
 


### PR DESCRIPTION
The boats panel checkboxes were not updating to reflect the initial visibility state. When boats were added to the visibleBoats Set in the $effect, the Set mutation wasn't triggering Svelte's reactivity system, causing checkboxes to show only "My Boat" as checked even though all boats were visible on the map.

Added `visibleBoats = new Set(visibleBoats)` after adding boats to trigger reactivity, matching the pattern already used in toggleBoatVisibility().