### PR TITLE
Fix memory leak

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "viam-chartplotter",
-	"version": "0.0.6",
+	"version": "0.0.7",
 	"private": true,
 	"scripts": {
 		"dev": "npm-run-all --parallel dev:*",


### PR DESCRIPTION
- Limit OpenLayers track features to 1000 and prune oldest when exceeded
- Clear track feature ID cache every 24 hours to prevent dictionary growth
- Add onDestroy cleanup for timeout loops (updateLoopTimeout, cloudLoopTimeout)
- Track and revoke camera blob URLs on component unmount
- Remove OpenLayers map event listeners on cleanup
- Limit position history to 7 days (10,080 points) to prevent unbounded array growth

Fixes memory leak that caused Firefox to consume 7GB+ when running overnight. Reported by John W.