### PR TITLE
Expose fitToVisibleBoats API and fix viewport fitting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "viam-chartplotter",
-	"version": "0.0.6",
+	"version": "0.0.7",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "viam-chartplotter",
-			"version": "0.0.6",
+			"version": "0.0.7",
 			"dependencies": {
 				"@ag-grid-community/client-side-row-model": "^32.3.5",
 				"@ag-grid-community/core": "^32.3.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "viam-chartplotter",
-	"version": "0.0.7",
+	"version": "0.0.8",
 	"private": true,
 	"scripts": {
 		"dev": "npm-run-all --parallel dev:*",

--- a/src/TestApp.svelte
+++ b/src/TestApp.svelte
@@ -143,85 +143,22 @@
   });
 </script>
 
-<main class="test-app">
-  <header>
-    <h1>MarineMap Test - Multi-Boat View</h1>
-    <p>Testing MarineMap component with {mockBoats.length} AIS boats (animated)</p>
-  </header>
-  
-  <div class="map-wrapper">
-    <MarineMap 
-      boats={mockBoats} 
-      zoomModifier={-8}
-      enableBoatsPanel={true}
-    />
-  </div>
-
-  <div class="boat-list">
-    <h2>Active Boats ({mockBoats.length})</h2>
-    <table>
-      <thead>
-        <tr>
-          <th>Name</th>
-          <th>MMSI</th>
-          <th>Speed (kn)</th>
-          <th>Heading</th>
-          <th>Position</th>
-        </tr>
-      </thead>
-      <tbody>
-        {#each mockBoats as boat}
-          <tr>
-            <td>{boat.name}</td>
-            <td>{boat.mmsi}</td>
-            <td>{boat.speed.toFixed(1)}</td>
-            <td>{boat.heading}°</td>
-            <td>{boat.location[0].toFixed(4)}°N, {Math.abs(boat.location[1]).toFixed(4)}°W</td>
-          </tr>
-        {/each}
-      </tbody>
-    </table>
-  </div>
-</main>
+<div class="map-wrapper">
+  <MarineMap 
+    boats={mockBoats} 
+    zoomModifier={-8}
+    enableBoatsPanel={true}
+  />
+</div>
 
 <style>
-  .test-app {
-    padding: 16px;
-    font-family: system-ui, -apple-system, sans-serif;
-    background: #1a1a2e;
-    color: #e0e0e0;
-    min-height: 100vh;
-    max-width: 100%;
-    box-sizing: border-box;
-  }
-
-  header {
-    margin-bottom: 12px;
-  }
-
-  h1, h2 {
-    color: #fff;
-    margin-bottom: 4px;
-  }
-
-  h1 {
-    font-size: 1.5rem;
-  }
-
-  p {
-    color: #888;
-    margin-bottom: 0;
-    font-size: 0.9rem;
-  }
-
   .map-wrapper {
-    width: 100%;
-    aspect-ratio: 21 / 9;
-    border: 1px solid #333;
-    border-radius: 8px;
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100vw;
+    height: 100vh;
     overflow: hidden;
-    position: relative;
-    margin-bottom: 20px;
   }
 
   .map-wrapper :global(#map-container) {
@@ -232,42 +169,5 @@
   .map-wrapper :global(#map) {
     width: 100%;
     height: 100%;
-  }
-
-  .boat-list {
-    margin-top: 0;
-  }
-
-  .boat-list h2 {
-    margin-bottom: 12px;
-  }
-
-  table {
-    width: 100%;
-    border-collapse: collapse;
-    background: #16213e;
-    border: 1px solid #333;
-    border-radius: 4px;
-  }
-
-  th, td {
-    padding: 10px 14px;
-    text-align: left;
-    border-bottom: 1px solid #333;
-  }
-
-  th {
-    background: #0f3460;
-    font-weight: 600;
-    color: #e0e0e0;
-    border-bottom: 2px solid #444;
-  }
-
-  td {
-    color: #ccc;
-  }
-
-  tr:hover {
-    background: #1f4068;
   }
 </style>

--- a/src/TestApp.svelte
+++ b/src/TestApp.svelte
@@ -94,6 +94,14 @@
       heading: 350,
       positionHistory: generateTrack(25.1, -79.15, 25.5, -79.0, 24),
     },
+    {
+      name: "Pacific Wanderer",
+      mmsi: "999000111",
+      location: [35.6, 139.7], // Tokyo Bay, Japan
+      speed: 11.0,
+      heading: 225,
+      positionHistory: generateTrack(35.8, 139.9, 35.6, 139.7, 24),
+    },
   ]);
 
   // Mock historical track for my boat (24 hours)

--- a/src/marineMap.svelte
+++ b/src/marineMap.svelte
@@ -500,8 +500,10 @@ import type { BoatInfo } from './lib/BoatInfo';
      on : true,
      layer : new TileLayer({
        opacity: 1,
+       preload: 4, // Preload tiles at lower zoom levels
        source: new XYZ({
-         url: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png'
+         url: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
+         transition: 300, // Fade-in duration in ms
        })
      }),
    })
@@ -512,11 +514,13 @@ import type { BoatInfo } from './lib/BoatInfo';
      on: false,
      layer: new TileLayer({
        opacity: .7,
+       preload: 2,
        source: new TileWMS({
          url: 'https://geoserver.openseamap.org/geoserver/gwc/service/wms',
          params: {'LAYERS': 'gebco2021:gebco_2021', 'VERSION':'1.1.1'},
          serverType: 'geoserver',
          hidpi: false,
+         transition: 300,
        }),
      }),
    })
@@ -528,10 +532,12 @@ import type { BoatInfo } from './lib/BoatInfo';
      layer : new TileLayer({
        visible: true,
        maxZoom: 19,
+       preload: 2,
        source: new XYZ({
          tileUrlFunction: function(coordinate) {
            return getTileUrlFunction("https://tiles.openseamap.org/seamark/", 'png', coordinate);
-   }
+         },
+         transition: 300,
        }),
        properties: {
          name: "seamarks",
@@ -547,12 +553,11 @@ import type { BoatInfo } from './lib/BoatInfo';
      on: false,
      layer: new TileLayer({
        opacity: .7,
+       preload: 2,
        source: new TileWMS({
          url: "https://gis.charttools.noaa.gov/arcgis/rest/services/MCS/NOAAChartDisplay/MapServer/exts/MaritimeChartService/WMSServer",
          params: {},
-         //ratio: 1,
-         //serverType: 'geoserver',
-         //hidpi: false,
+         transition: 300,
        }),
      }),
    })

--- a/src/marineMap.svelte
+++ b/src/marineMap.svelte
@@ -85,19 +85,24 @@ import type { BoatInfo } from './lib/BoatInfo';
    visibleBoats = new Set(visibleBoats); // Trigger reactivity
  }
 
+ function isValidCoordinate(lat: number, lng: number): boolean {
+   return lat >= -90 && lat <= 90 && lng >= -180 && lng <= 180 && 
+          !(lat === 0 && lng === 0); // Exclude null island
+ }
+
  function fitToVisibleBoats() {
    if (!mapGlobal.map || !mapGlobal.view) return;
 
    const coords: number[][] = [];
 
-   // Add my boat if visible
-   if (myBoat && visibleBoats.has('myBoat') && (myBoat.location[0] !== 0 || myBoat.location[1] !== 0)) {
+   // Add my boat if visible and has valid coordinates
+   if (myBoat && visibleBoats.has('myBoat') && isValidCoordinate(myBoat.location[0], myBoat.location[1])) {
      coords.push([myBoat.location[1], myBoat.location[0]]); // [lng, lat]
    }
 
-   // Add visible AIS boats
+   // Add visible AIS boats with valid coordinates
    boats?.forEach(boat => {
-     if (boat.mmsi && visibleBoats.has(boat.mmsi)) {
+     if (boat.mmsi && visibleBoats.has(boat.mmsi) && isValidCoordinate(boat.location[0], boat.location[1])) {
        coords.push([boat.location[1], boat.location[0]]);
      }
    });
@@ -108,7 +113,7 @@ import type { BoatInfo } from './lib/BoatInfo';
      // Single boat - center on it with reasonable zoom
      mapGlobal.view.animate({
        center: coords[0],
-       zoom: 10,
+       zoom: Math.min(12, Math.max(8, mapGlobal.view.getZoom() ?? 10)),
        duration: 500
      });
    } else {


### PR DESCRIPTION
Expose the fitToVisibleBoats() function to parent components and fix issues with boats being cut off when fitting the view on wider screens.

**Changes**
- New onReady callback prop - Allows parent components to access the map API without needing to remount the entire map component
- Responsive padding - Changed from fixed pixel padding to percentage-based padding that scales with viewport size (10% horizontal, 10% vertical, 15% top for popups)
- Added updateSize() call - Ensures map has correct dimensions before fitting
- Added coordinate validation helper - isValidCoordinate() function to validate lat/lng ranges and exclude null island (0,0)

<img width="1800" height="1004" alt="image" src="https://github.com/user-attachments/assets/71af11f2-d399-45dd-9ce2-faad42f674c8" />
