### PR TITLE
Fix boat popup clipping and improve boats panel UX

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "viam-chartplotter",
-	"version": "0.0.9",
+	"version": "0.0.10",
 	"private": true,
 	"scripts": {
 		"dev": "npm-run-all --parallel dev:*",

--- a/src/TestApp.svelte
+++ b/src/TestApp.svelte
@@ -181,6 +181,25 @@
     zoomModifier={-8}
     enableBoatsPanel={true}
     onReady={(api) => mapApi = api}
+    fitBoundsPadding={{ top: 250, right: 100, bottom: 100, left: 100 }}
+    boatDetailSlot={(boat) => {
+      return {
+        render: () => `
+          <div style="width: 200px; padding: 8px; background: linear-gradient(135deg, #1e3a8a 0%, #3b82f6 100%); border-radius: 4px; color: white;">
+            <div style="font-size: 11px; font-weight: 600; margin-bottom: 8px; opacity: 0.9;">VESSEL INFO</div>
+            <div style="font-size: 10px; line-height: 1.6;">
+              <div style="margin-bottom: 4px;"><span style="opacity: 0.7;">MMSI:</span> <span style="font-family: monospace;">${boat.name?.includes('Runner') ? '369' : '367'}${Math.floor(Math.random() * 1000000).toString().padStart(6, '0')}</span></div>
+              <div style="margin-bottom: 4px;"><span style="opacity: 0.7;">Type:</span> ${boat.name?.includes('Freighter') ? 'Cargo' : 'Pleasure Craft'}</div>
+              <div style="margin-bottom: 4px;"><span style="opacity: 0.7;">Length:</span> ${Math.floor(Math.random() * 40) + 30}m</div>
+              <div style="margin-bottom: 4px;"><span style="opacity: 0.7;">Beam:</span> ${Math.floor(Math.random() * 10) + 8}m</div>
+              <div style="margin-bottom: 4px;"><span style="opacity: 0.7;">Draft:</span> ${(Math.random() * 3 + 2).toFixed(1)}m</div>
+              <div style="margin-bottom: 4px;"><span style="opacity: 0.7;">Destination:</span> ${['MIAMI', 'KEY WEST', 'TAMPA', 'NASSAU', 'FREEPORT'][Math.floor(Math.random() * 5)]}</div>
+              <div style="opacity: 0.7; font-size: 9px; margin-top: 8px; padding-top: 8px; border-top: 1px solid rgba(255,255,255,0.2);">Last Update: ${new Date().toLocaleTimeString()}</div>
+            </div>
+          </div>
+        `
+      }
+    }}
   />
 </div>
 

--- a/src/marineMap.svelte
+++ b/src/marineMap.svelte
@@ -124,13 +124,34 @@ import type { BoatInfo } from './lib/BoatInfo';
      const extent = boundingExtent(coords);
      const mapSize = mapGlobal.map?.getSize() || [800, 600];
      const [width, height] = mapSize;
-     // Use percentage-based padding that scales with viewport, minimum 80px
-     const horizontalPad = Math.max(80, width * 0.1);
-     const verticalPad = Math.max(80, height * 0.1);
-     const topPad = Math.max(120, height * 0.15); // Extra top padding for popups
+     
+     // Calculate default padding values
+     const defaultHorizontalPad = Math.max(80, width * 0.1);
+     const defaultVerticalPad = Math.max(80, height * 0.1);
+     const defaultTopPad = Math.max(250, height * 0.15); // Extra top padding for 223px popup height
+     
+     // Apply custom padding if provided, otherwise use defaults
+     let topPad: number, rightPad: number, bottomPad: number, leftPad: number;
+     
+     if (typeof fitBoundsPadding === 'number') {
+       // Single number applies to all edges
+       topPad = rightPad = bottomPad = leftPad = fitBoundsPadding;
+     } else if (fitBoundsPadding) {
+       // Object with individual edge overrides
+       topPad = fitBoundsPadding.top ?? defaultTopPad;
+       rightPad = fitBoundsPadding.right ?? defaultHorizontalPad;
+       bottomPad = fitBoundsPadding.bottom ?? defaultVerticalPad;
+       leftPad = fitBoundsPadding.left ?? defaultHorizontalPad;
+     } else {
+       // Use all defaults
+       topPad = defaultTopPad;
+       rightPad = defaultHorizontalPad;
+       bottomPad = defaultVerticalPad;
+       leftPad = defaultHorizontalPad;
+     }
      
      mapGlobal.view.fit(extent, {
-       padding: [topPad, horizontalPad, verticalPad, horizontalPad],
+       padding: [topPad, rightPad, bottomPad, leftPad],
        duration: 500,
        maxZoom: 12
      });
@@ -139,7 +160,7 @@ import type { BoatInfo } from './lib/BoatInfo';
    mapInternalState.inPanMode = true; // Prevent auto-centering
  }
 
- let { myBoat, zoomModifier, boats, positionHistorical, enableBoatsPanel = false, onReady, boatDetailSlot }: {
+ let { myBoat, zoomModifier, boats, positionHistorical, enableBoatsPanel = false, onReady, boatDetailSlot, fitBoundsPadding }: {
   myBoat?: BoatInfo;
   zoomModifier?: number;
   boats?: BoatInfo[];
@@ -147,6 +168,7 @@ import type { BoatInfo } from './lib/BoatInfo';
   enableBoatsPanel?: boolean;
   onReady?: (api: { fitToVisibleBoats: () => void }) => void;
   boatDetailSlot?: (boat: { host?: string; partId?: string; name: string }) => any;
+  fitBoundsPadding?: number | { top?: number; right?: number; bottom?: number; left?: number };
 } = $props();
 
  // Create derived values for reactivity tracking

--- a/src/marineMap.svelte
+++ b/src/marineMap.svelte
@@ -88,6 +88,19 @@ import type { BoatInfo } from './lib/BoatInfo';
    visibleBoats = new Set(visibleBoats); // Trigger reactivity
  }
 
+ function selectAllBoats() {
+   const allIds = new Set<string>();
+   if (myBoat) allIds.add('myBoat');
+   boats?.forEach(b => {
+     if (b.mmsi) allIds.add(b.mmsi);
+   });
+   visibleBoats = allIds;
+ }
+
+ function deselectAllBoats() {
+   visibleBoats = new Set();
+ }
+
  function isValidCoordinate(lat: number, lng: number): boolean {
    return lat >= -90 && lat <= 90 && lng >= -180 && lng <= 180 && 
           !(lat === 0 && lng === 0); // Exclude null island
@@ -1056,6 +1069,10 @@ import type { BoatInfo } from './lib/BoatInfo';
   {#if enableBoatsPanel}
   <!-- Boats Panel (bottom-right, next to Layers) -->
   <div class="boats-panel">
+    <div class="boats-controls">
+      <button class="select-btn" onclick={selectAllBoats} title="Select all boats">Select all</button>
+      <button class="select-btn" onclick={deselectAllBoats} title="Deselect all boats">Deselect all</button>
+    </div>
     <div class="boats-list">
       {#if myBoat}
       <label class="boat-item">
@@ -1296,6 +1313,36 @@ import type { BoatInfo } from './lib/BoatInfo';
   }
 
   /* Boats panel (bottom-right, next to Layers) */
+  .boats-controls {
+    display: flex;
+    gap: 6px;
+    padding: 6px 6px;
+    border-bottom: 1px solid rgba(0, 0, 0, 0.1);
+  }
+
+  .select-btn {
+    flex: 1;
+    padding: 4px 8px;
+    font-size: 10px;
+    font-weight: 500;
+    background: rgba(232, 232, 232, 0.2);
+    color: #444;
+    border: 1px solid rgba(167, 167, 167, 0.3);
+    border-radius: 3px;
+    cursor: pointer;
+    transition: all 0.2s;
+  }
+
+  .select-btn:hover {
+    background: rgba(219, 219, 219, 0.3);
+    border: 1px solid rgba(167, 167, 167, 0.4);
+    color: #444;
+  }
+
+  .select-btn:active {
+    transform: scale(0.98);
+  }
+
   .boats-panel {
     position: absolute;
     bottom: 45px;
@@ -1322,7 +1369,7 @@ import type { BoatInfo } from './lib/BoatInfo';
   .boats-list {
     flex: 1;
     overflow-y: auto;
-    padding: 10px 14px;
+    padding: 6px 14px;
     padding-bottom: 0;
     max-height: 200px;
     -webkit-overflow-scrolling: touch; /* Smooth scrolling on iOS */


### PR DESCRIPTION
Boat popups (346x223px) were getting clipped when using "Fit All Visible" due to insufficient padding.

- Increased default top padding from 120px → 250px to accommodate 223px popup height
- Added fitBoundsPadding prop for client customization (supports single number or per-edge object)
- Added Select All / Deselect All buttons to boats panel for better visibility management

```
<MarineMap 
  fitBoundsPadding={250}  // or { top: 250, right: 100, ... }
  enableBoatsPanel={true}
/>
```