### PR TITLE
Improve boat visibility control

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "viam-chartplotter",
-	"version": "0.0.10",
+	"version": "0.0.11",
 	"private": true,
 	"scripts": {
 		"dev": "npm-run-all --parallel dev:*",

--- a/src/marineMap.svelte
+++ b/src/marineMap.svelte
@@ -96,7 +96,10 @@ import type { BoatInfo } from './lib/BoatInfo';
    const allIds = new Set<string>();
    if (myBoat) allIds.add('myBoat');
    boats?.forEach(b => {
-     if (b.mmsi) allIds.add(b.mmsi);
+     // Only add offline boats if showOfflineBoatsInPanel is true
+     if (b.mmsi && (b.isOnline !== false || showOfflineBoatsInPanel)) {
+       allIds.add(b.mmsi);
+     }
    });
    visibleBoats = allIds;
  }

--- a/src/marineMap.svelte
+++ b/src/marineMap.svelte
@@ -65,20 +65,24 @@ import type { BoatInfo } from './lib/BoatInfo';
  let visibleBoats = $state<Set<string>>(new Set(['myBoat']));
 
  // Initialize visibleBoats when boats prop changes (only when NOT using external control)
- let lastBoatsLength = $state(0);
+ // Use plain JS variable for tracking to avoid creating effect dependencies
+ let lastBoatsLength = 0;
  $effect(() => {
    // Skip auto-add when parent is controlling visibility externally
    if (externalVisibilityControl) return;
    
-   const currentLength = boats?.length ?? 0;
+   // Read boats to create dependency
+   const boatsList = boats;
+   const currentLength = boatsList?.length ?? 0;
+   
    if (currentLength !== lastBoatsLength) {
      // Add any new boats to visible set
-     boats?.forEach(b => {
+     boatsList?.forEach(b => {
        if (b.mmsi && !visibleBoats.has(b.mmsi)) {
          visibleBoats.add(b.mmsi);
        }
      });
-     lastBoatsLength = currentLength;
+     lastBoatsLength = currentLength; // Plain JS variable, won't re-trigger
      visibleBoats = new Set(visibleBoats); // Trigger reactivity
    }
  });

--- a/src/marineMap.svelte
+++ b/src/marineMap.svelte
@@ -446,7 +446,9 @@ import type { BoatInfo } from './lib/BoatInfo';
      const toRemove = mapGlobal.trackFeatures.getLength() - maxFeatures;
      for (let i = 0; i < toRemove; i++) {
        var x = mapGlobal.trackFeatures.item(0);
-       delete mapInternalState.trackFeatureIds[x["myid"]];
+       if (x) {
+         delete mapInternalState.trackFeatureIds[x.get("myid")];
+       }
        mapGlobal.trackFeatures.removeAt(0);
      }
    }


### PR DESCRIPTION
Fixes show offline checkbox behavior - now instantly shows/hides offline boats without lag or checking online boats.

Changes:
- Boat visibility now controlled via API instead of destroying/recreating components
- Show offline toggle only adds/removes offline boats, preserves manual selections
- Boats panel separates online/offline boats with visual distinction