### PR TITLE
Jason fish detections on map

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .DS_Store
+.vscode/
 node_modules
 /dist
 /build

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1072,7 +1072,7 @@ import type { BoatInfo } from './lib/BoatInfo';
       distanceToWaypoint: globalData.route["Distance to Waypoint"],
       waypointClosingVelocity: globalData.route["Waypoint Closing Velocity"]
     } : undefined
-  }} zoomModifier={globalConfig.zoomModifier} boats={globalData.aisBoats} positionHistorical={globalData.posHistory}>
+  }} zoomModifier={globalConfig.zoomModifier} boats={globalData.aisBoats} positionHistorical={globalData.posHistory} defaultAisVisible={false}>
   </MarineMap>
     
   

--- a/src/lib/BoatInfo.ts
+++ b/src/lib/BoatInfo.ts
@@ -7,7 +7,7 @@ export interface PositionPoint {
 export interface Detection {
   id: string;
   timestamp: Date;
-  boatId?: string;
+  boatId: string;
   metadata?: Record<string, any>;
 }
 

--- a/src/lib/BoatInfo.ts
+++ b/src/lib/BoatInfo.ts
@@ -1,7 +1,7 @@
 export interface PositionPoint {
   lat: number;
   lng: number;
-  ts: Date;
+  ts?: Date;
 }
 
 export interface Detection {

--- a/src/lib/BoatInfo.ts
+++ b/src/lib/BoatInfo.ts
@@ -1,3 +1,18 @@
+/** A single position point with optional timestamp */
+export interface PositionPoint {
+  lat: number;
+  lng: number;
+  ts?: Date; // Timestamp for this position
+}
+
+/** A detection event to be displayed on the map */
+export interface Detection {
+  id: string; // Unique identifier for this detection
+  timestamp: Date; // When the detection occurred
+  boatId?: string; // The boat/partId associated with this detection
+  metadata?: Record<string, any>; // Application-specific metadata
+}
+
 export interface BoatInfo {
   name: string;
   location: [number, number]; // [latitude, longitude]
@@ -13,5 +28,5 @@ export interface BoatInfo {
     distanceToWaypoint?: number;
     waypointClosingVelocity?: number;
   };
-  positionHistory?: { lat: number; lng: number }[]; // Historical track positions
+  positionHistory?: PositionPoint[]; // Historical track positions with optional timestamps
 }

--- a/src/lib/BoatInfo.ts
+++ b/src/lib/BoatInfo.ts
@@ -11,6 +11,14 @@ export interface Detection {
   metadata?: Record<string, any>;
 }
 
+export interface DetectionConfig {
+  detections?: Detection[];
+  enabled?: boolean;
+  loading?: boolean;
+  onToggle?: (enabled: boolean, boatPartId?: string) => void;
+  onClick?: (detection: Detection) => void;
+}
+
 export interface BoatInfo {
   name: string;
   location: [number, number]; // [latitude, longitude]

--- a/src/lib/BoatInfo.ts
+++ b/src/lib/BoatInfo.ts
@@ -1,7 +1,7 @@
 export interface PositionPoint {
   lat: number;
   lng: number;
-  ts?: Date;
+  ts: Date;
 }
 
 export interface Detection {

--- a/src/lib/BoatInfo.ts
+++ b/src/lib/BoatInfo.ts
@@ -1,16 +1,14 @@
-/** A single position point with optional timestamp */
 export interface PositionPoint {
   lat: number;
   lng: number;
-  ts?: Date; // Timestamp for this position
+  ts?: Date;
 }
 
-/** A detection event to be displayed on the map */
 export interface Detection {
-  id: string; // Unique identifier for this detection
-  timestamp: Date; // When the detection occurred
-  boatId?: string; // The boat/partId associated with this detection
-  metadata?: Record<string, any>; // Application-specific metadata
+  id: string;
+  timestamp: Date;
+  boatId?: string;
+  metadata?: Record<string, any>;
 }
 
 export interface BoatInfo {
@@ -28,5 +26,5 @@ export interface BoatInfo {
     distanceToWaypoint?: number;
     waypointClosingVelocity?: number;
   };
-  positionHistory?: PositionPoint[]; // Historical track positions with optional timestamps
+  positionHistory?: PositionPoint[];
 }

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,3 +1,3 @@
 // place files you want to import through the `$lib` alias in this folder.
-export type { BoatInfo, PositionPoint, Detection } from './BoatInfo';
+export type { BoatInfo, PositionPoint, Detection, DetectionConfig } from './BoatInfo';
 export { default as MarineMap } from '../marineMap.svelte';

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,3 +1,3 @@
 // place files you want to import through the `$lib` alias in this folder.
-export type { BoatInfo } from './BoatInfo';
+export type { BoatInfo, PositionPoint, Detection } from './BoatInfo';
 export { default as MarineMap } from '../marineMap.svelte';

--- a/src/marineMap.svelte
+++ b/src/marineMap.svelte
@@ -1318,6 +1318,10 @@ import type { BoatInfo, PositionPoint, Detection } from './lib/BoatInfo';
   {#if enableBoatsPanel}
   <!-- Boats Panel (bottom-right, next to Layers) -->
   <div class="boats-panel">
+    <div class="boats-controls">
+      <button class="select-btn" onclick={selectAllBoats} title="Select all boats">Select all</button>
+      <button class="select-btn" onclick={deselectAllBoats} title="Deselect all boats">Deselect all</button>
+    </div>
     <div class="boats-list">
       {#if myBoat}
       <label class="boat-item">
@@ -1357,10 +1361,6 @@ import type { BoatInfo, PositionPoint, Detection } from './lib/BoatInfo';
           {/each}
         {/if}
       {/if}
-    </div>
-    <div class="boats-controls">
-      <button class="select-btn" onclick={selectAllBoats} title="Select all boats">Select all</button>
-      <button class="select-btn" onclick={deselectAllBoats} title="Deselect all boats">Deselect all</button>
     </div>
     <input
       type="text"

--- a/src/marineMap.svelte
+++ b/src/marineMap.svelte
@@ -199,7 +199,7 @@ import type { BoatInfo, PositionPoint, Detection } from './lib/BoatInfo';
    mapInternalState.inPanMode = true; // Prevent auto-centering
  }
 
- let { myBoat, zoomModifier, boats, positionHistorical, enableBoatsPanel = false, externalVisibilityControl = false, showOfflineBoatsInPanel = true, onReady, boatDetailSlot, fitBoundsPadding, onShowDetections, onBoatPopupOpen, detections, detectionsLabel = "Show Detections", detectionsLayerName = "detections", detectionsLayerDisplayName = "detections", detectionsLoading = false, onDetectionClick }: {
+ let { myBoat, zoomModifier, boats, positionHistorical, enableBoatsPanel = false, externalVisibilityControl = false, showOfflineBoatsInPanel = true, defaultAisVisible = true, onReady, boatDetailSlot, fitBoundsPadding, onShowDetections, onBoatPopupOpen, detections, detectionsLabel = "Show Detections", detectionsLayerName = "detections", detectionsLayerDisplayName = "detections", detectionsLoading = false, onDetectionClick }: {
   myBoat?: BoatInfo;
   zoomModifier?: number;
   boats?: BoatInfo[];
@@ -209,7 +209,8 @@ import type { BoatInfo, PositionPoint, Detection } from './lib/BoatInfo';
   externalVisibilityControl?: boolean;
   /** When false, offline boats are hidden from the boats panel (default: true) */
   showOfflineBoatsInPanel?: boolean;
-  onReady?: (api: {
+  defaultAisVisible?: boolean;
+  onReady?: (api: { 
     fitToVisibleBoats: () => void;
     selectAllBoats: () => void;
     deselectAllBoats: () => void;
@@ -929,7 +930,7 @@ import type { BoatInfo, PositionPoint, Detection } from './lib/BoatInfo';
    mapGlobal.layerOptions.push({
      name: "ais-track",
      displayName: "track",
-     on: true,
+     on: defaultAisVisible,
      layer: aisTrackLayer,
      parent: "ais",
    });

--- a/src/marineMap.svelte
+++ b/src/marineMap.svelte
@@ -551,12 +551,11 @@
    history: PositionPoint[],
    targetTime: Date
  ): { lat: number; lng: number } | null {
-   const timedPoints = history.filter((p) => p.ts !== undefined);
-   if (timedPoints.length === 0) return null;
+   if (history.length === 0) return null;
 
    const targetMs = targetTime.getTime();
-   const closest = timedPoints.reduce((a, b) =>
-     Math.abs(a.ts!.getTime() - targetMs) <= Math.abs(b.ts!.getTime() - targetMs) ? a : b
+   const closest = history.reduce((a, b) =>
+     Math.abs(a.ts.getTime() - targetMs) <= Math.abs(b.ts.getTime() - targetMs) ? a : b
    );
 
    return { lat: closest.lat, lng: closest.lng };

--- a/src/marineMap.svelte
+++ b/src/marineMap.svelte
@@ -239,7 +239,6 @@
   boatDetailSlot?: (boat: { host?: string; partId?: string; name: string }) => any;
   fitBoundsPadding?: number | { top?: number; right?: number; bottom?: number; left?: number };
   onBoatPopupOpen?: (boatPartId?: string) => void;
-  /** Configuration for detection markers on the map */
   detectionConfig?: DetectionConfig;
 } = $props();
 
@@ -296,7 +295,6 @@
    if (shouldClose) closePopup();
  });
 
- // Force track layers to re-render when effective visibility changes (includes search filter)
  $effect(() => {
    const _visible = effectiveVisibleKey;
    // Trigger style recalculation by notifying the track layers

--- a/src/marineMap.svelte
+++ b/src/marineMap.svelte
@@ -218,7 +218,7 @@
    mapInternalState.inPanMode = true; // Prevent auto-centering
  }
 
- let { myBoat, zoomModifier, boats, positionHistorical, enableBoatsPanel = false, externalVisibilityControl = false, showOfflineBoatsInPanel = true, defaultAisVisible = true, onReady, boatDetailSlot, fitBoundsPadding, onShowDetections, onBoatPopupOpen, detections, detectionsLabel = "Show Detections", enableDetectionsCheckbox = false, detectionsLoading = false, onDetectionClick }: {
+ let { myBoat, zoomModifier, boats, positionHistorical, enableBoatsPanel = false, externalVisibilityControl = false, showOfflineBoatsInPanel = true, defaultAisVisible = true, onReady, boatDetailSlot, fitBoundsPadding, onShowDetections, onBoatPopupOpen, detections, enableDetectionsCheckbox = false, detectionsLoading = false, onDetectionClick }: {
   myBoat?: BoatInfo;
   zoomModifier?: number;
   boats?: BoatInfo[];
@@ -241,7 +241,6 @@
   onShowDetections?: (enabled: boolean, boatPartId?: string) => void;
   onBoatPopupOpen?: (boatPartId?: string) => void;
   detections?: Detection[];
-  detectionsLabel?: string;
   /** When true, shows the detections checkbox in boat popups (default: false) */
   enableDetectionsCheckbox?: boolean;
   detectionsLoading?: boolean;
@@ -1285,7 +1284,7 @@
     {#if enableDetectionsCheckbox}
       <label class="popup-checkbox">
         <input type="checkbox" bind:checked={showDetections} />
-        {detectionsLabel}
+        Show Detections
         {#if detectionsLoading}
           <span class="loading-spinner"></span>
         {/if}

--- a/src/marineMap.svelte
+++ b/src/marineMap.svelte
@@ -578,28 +578,21 @@ import type { BoatInfo, PositionPoint, Detection } from './lib/BoatInfo';
    const features: Feature<Point>[] = [];
 
    detections.forEach((detection) => {
-     let position: { lat: number; lng: number } | null = null;
+    const history = allHistories[detection.boatId];
+    if (!history) return;
+    
+    const position = getPositionAtTime(history, detection.timestamp);
+    if (!position) return;
+    
+    const feature = new Feature({
+      type: 'detection',
+      detectionId: detection.id,
+      timestamp: detection.timestamp,
+      detectionData: detection,
+      geometry: new Point([position.lng, position.lat]),
+    });
 
-     if (detection.boatId && allHistories[detection.boatId]) {
-       position = getPositionAtTime(allHistories[detection.boatId], detection.timestamp);
-     } else {
-       for (const boatId of Object.keys(allHistories)) {
-         position = getPositionAtTime(allHistories[boatId], detection.timestamp);
-         if (position) break;
-       }
-     }
-
-     if (position) {
-       const feature = new Feature({
-         type: 'detection',
-         detectionId: detection.id,
-         timestamp: detection.timestamp,
-         detectionData: detection,
-         geometry: new Point([position.lng, position.lat]),
-       });
-
-       features.push(feature);
-     }
+    features.push(feature);
    });
 
    source.addFeatures(features);


### PR DESCRIPTION
**Forked from Ian's work: Add detection markers (opt in only), and boat search**

- Cleanup: Add DetectionConfig prop to display detection markers (white triangles with transparent green fill) on boat tracks
- Update boat search input to filter boats panel and hide boats/markers appropriately
- Add onBoatPopupOpen callback for popup interactions
- Add PositionPoint type with optional timestamp for position history
- Add zIndex to layers for proper stacking order