### PR TITLE
Add navigation waypoint management to chartplotter

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,13 +41,14 @@ whole route.
   "attributes": {
     "movement_sensor": "gps",
     "data_path": "/var/lib/viam-chartplotter/nav.json"
-  },
-  "depends_on": ["gps"]
+  }
 }
 ```
 
-Both `attributes` fields are optional. The minimal config is just `model`
-plus `name`/`type`/`namespace`; in that case `Location` returns (0, 0) and
+Both `attributes` fields are optional — the dependency on `movement_sensor`
+is reported automatically from the service's config validator, so no
+explicit `depends_on` is needed. The minimal config is just `model` plus
+`name`/`type`/`namespace`; in that case `Location` returns (0, 0) and
 waypoints are written to the default cache path.
 
 ## Developing

--- a/README.md
+++ b/README.md
@@ -25,10 +25,11 @@ whole route.
 
 ### Configuration attributes
 
-| Name              | Type   | Required | Description                                                                                                                                                  |
-| ----------------- | ------ | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `movement_sensor` | string | no       | Name of a movement sensor on the same machine. When set, the service's `Location` method reports that sensor's live position and compass heading.            |
-| `data_path`       | string | no       | Absolute path to the JSON file used to persist waypoints. Defaults to `<user-cache-dir>/viam-chartplotter/nav/<service-name>.json`.                          |
+| Name                | Type   | Required | Description                                                                                                                                                                                                                                  |
+| ------------------- | ------ | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `movement_sensor`   | string | no       | Name of a movement sensor on the same machine. When set, the service's `Location` method reports that sensor's live position and compass heading, and the auto-arrival poller uses it to detect waypoint arrivals.                           |
+| `data_path`         | string | no       | Absolute path to the JSON file used to persist waypoints. Defaults to `<user-cache-dir>/viam-chartplotter/nav/<service-name>.json`.                                                                                                          |
+| `arrival_radius_m`  | number | no       | When `movement_sensor` is set, the next waypoint is automatically marked visited (and disappears from the route) once the boat is within this many meters of it. Defaults to `200`. Set to a negative number to disable, or omit to use the default. |
 
 ### Sample config
 
@@ -40,7 +41,8 @@ whole route.
   "model": "erh:viam-chartplotter:nav",
   "attributes": {
     "movement_sensor": "gps",
-    "data_path": "/var/lib/viam-chartplotter/nav.json"
+    "data_path": "/var/lib/viam-chartplotter/nav.json",
+    "arrival_radius_m": 200
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -13,6 +13,43 @@
 - Later Cool Stuff
   \*\* tides
 
+## Navigation service
+
+The `erh:viam-chartplotter:nav` model is an `rdk:service:navigation`
+implementation backed by an in-memory waypoint list that is mirrored to a JSON
+file on disk so waypoints survive module restarts. The chartplotter UI auto-
+detects this service, draws the current waypoints as an amber dashed route
+from the boat through each waypoint, and exposes buttons to add a waypoint at
+the boat's current position, drop one by clicking on the chart, or clear the
+whole route.
+
+### Configuration attributes
+
+| Name              | Type   | Required | Description                                                                                                                                                  |
+| ----------------- | ------ | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `movement_sensor` | string | no       | Name of a movement sensor on the same machine. When set, the service's `Location` method reports that sensor's live position and compass heading.            |
+| `data_path`       | string | no       | Absolute path to the JSON file used to persist waypoints. Defaults to `<user-cache-dir>/viam-chartplotter/nav/<service-name>.json`.                          |
+
+### Sample config
+
+```json
+{
+  "name": "nav",
+  "namespace": "rdk",
+  "type": "navigation",
+  "model": "erh:viam-chartplotter:nav",
+  "attributes": {
+    "movement_sensor": "gps",
+    "data_path": "/var/lib/viam-chartplotter/nav.json"
+  },
+  "depends_on": ["gps"]
+}
+```
+
+Both `attributes` fields are optional. The minimal config is just `model`
+plus `name`/`type`/`namespace`; in that case `Location` returns (0, 0) and
+waypoints are written to the default cache path.
+
 ## Developing
 
 ```

--- a/cmd/module/cmd.go
+++ b/cmd/module/cmd.go
@@ -4,6 +4,7 @@ import (
 	"go.viam.com/rdk/components/generic"
 	"go.viam.com/rdk/module"
 	"go.viam.com/rdk/resource"
+	"go.viam.com/rdk/services/navigation"
 
 	"github.com/erh/viam-chartplotter"
 )
@@ -11,6 +12,7 @@ import (
 func main() {
 	module.ModularMain(
 		resource.APIModel{generic.API, vc.Model},
+		resource.APIModel{navigation.API, vc.NavModel},
 	)
 
 }

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,9 @@ require (
 	github.com/beetlebugorg/s57 v0.100.0
 	github.com/erh/vmodutils v0.0.4-0.20250505141807-8c2b0355a0a3
 	github.com/fogleman/gg v1.3.0
+	github.com/kellydunn/golang-geo v0.7.0
+	github.com/pkg/errors v0.9.1
+	go.mongodb.org/mongo-driver v1.17.1
 	go.viam.com/rdk v0.73.1-0.20250505140427-608c7b61f924
 	golang.org/x/image v0.19.0
 )
@@ -21,6 +24,7 @@ require (
 	github.com/a8m/envsubst v1.4.2 // indirect
 	github.com/ajstarks/svgo v0.0.0-20211024235047-1546f124cd8b // indirect
 	github.com/beetlebugorg/iso8211 v0.100.0 // indirect
+	github.com/benbjohnson/clock v1.3.5 // indirect
 	github.com/bep/debounce v1.2.1 // indirect
 	github.com/bluenviron/gortsplib/v4 v4.8.0 // indirect
 	github.com/bufbuild/protocompile v0.9.0 // indirect
@@ -69,7 +73,6 @@ require (
 	github.com/improbable-eng/grpc-web v0.15.0 // indirect
 	github.com/jedib0t/go-pretty/v6 v6.4.6 // indirect
 	github.com/jhump/protoreflect v1.15.6 // indirect
-	github.com/kellydunn/golang-geo v0.7.0 // indirect
 	github.com/klauspost/compress v1.17.7 // indirect
 	github.com/kylelemons/go-gypsy v1.0.0 // indirect
 	github.com/lestrrat-go/backoff/v2 v2.0.8 // indirect
@@ -81,6 +84,7 @@ require (
 	github.com/lib/pq v1.10.9 // indirect
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
 	github.com/mattn/go-runewidth v0.0.16 // indirect
+	github.com/matttproud/golang_protobuf_extensions v1.0.4 // indirect
 	github.com/miekg/dns v1.1.53 // indirect
 	github.com/montanaflynn/stats v0.7.1 // indirect
 	github.com/muhlemmer/gu v0.3.1 // indirect
@@ -99,7 +103,6 @@ require (
 	github.com/pion/stun v0.6.1 // indirect
 	github.com/pion/transport/v2 v2.2.10 // indirect
 	github.com/pion/turn/v2 v2.1.6 // indirect
-	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/rs/cors v1.11.1 // indirect
@@ -120,7 +123,6 @@ require (
 	github.com/zitadel/schema v1.3.1 // indirect
 	github.com/ziutek/mymysql v1.5.4 // indirect
 	go-hep.org/x/hep v0.32.1 // indirect
-	go.mongodb.org/mongo-driver v1.17.1 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.54.0 // indirect

--- a/meta.json
+++ b/meta.json
@@ -8,6 +8,10 @@
     {
       "api": "rdk:component:generic",
       "model": "erh:viam-chartplotter:chartplotter"
+    },
+    {
+      "api": "rdk:service:navigation",
+      "model": "erh:viam-chartplotter:nav"
     }
   ],
   "first_run": "",

--- a/meta.json
+++ b/meta.json
@@ -11,7 +11,9 @@
     },
     {
       "api": "rdk:service:navigation",
-      "model": "erh:viam-chartplotter:nav"
+      "model": "erh:viam-chartplotter:nav",
+      "description": "Persistent in-memory navigation service for the chartplotter UI.",
+      "markdown_link": "README.md#navigation-service"
     }
   ],
   "first_run": "",

--- a/nav.go
+++ b/nav.go
@@ -169,8 +169,46 @@ func (s *navService) Properties(ctx context.Context) (navigation.Properties, err
 	return navigation.Properties{MapType: navigation.GPSMap}, nil
 }
 
+// DoCommand exposes service-specific commands that don't have a first-class
+// gRPC method on the navigation API. Currently:
+//
+//	{"move_waypoint": {"id": "<hex>", "lat": <float>, "lng": <float>}}
+//
+// updates an existing waypoint in place (preserving its ID and order).
 func (s *navService) DoCommand(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error) {
-	return nil, resource.ErrDoUnimplemented
+	raw, ok := cmd["move_waypoint"]
+	if !ok {
+		return nil, resource.ErrDoUnimplemented
+	}
+	m, ok := raw.(map[string]interface{})
+	if !ok {
+		return nil, errors.New("move_waypoint payload must be an object")
+	}
+	idStr, _ := m["id"].(string)
+	if idStr == "" {
+		return nil, errors.New("move_waypoint.id is required")
+	}
+	id, err := primitive.ObjectIDFromHex(idStr)
+	if err != nil {
+		return nil, errors.Wrapf(err, "invalid move_waypoint.id %q", idStr)
+	}
+	lat, latOK := m["lat"].(float64)
+	lng, lngOK := m["lng"].(float64)
+	if !latOK || !lngOK {
+		return nil, errors.New("move_waypoint.lat and move_waypoint.lng are required numbers")
+	}
+	mover, ok := s.store.(interface {
+		MoveWaypoint(ctx context.Context, id primitive.ObjectID, point *geo.Point) error
+	})
+	if !ok {
+		return nil, errors.New("waypoint store does not support move")
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if err := mover.MoveWaypoint(ctx, id, geo.NewPoint(lat, lng)); err != nil {
+		return nil, err
+	}
+	return map[string]interface{}{"ok": true}, nil
 }
 
 func (s *navService) Close(ctx context.Context) error {

--- a/nav.go
+++ b/nav.go
@@ -1,0 +1,164 @@
+package vc
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+
+	geo "github.com/kellydunn/golang-geo"
+	"github.com/pkg/errors"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+
+	"go.viam.com/rdk/components/movementsensor"
+	"go.viam.com/rdk/logging"
+	"go.viam.com/rdk/resource"
+	"go.viam.com/rdk/services/navigation"
+	"go.viam.com/rdk/spatialmath"
+)
+
+var NavModel = resource.ModelNamespace("erh").WithFamily("viam-chartplotter").WithModel("nav")
+
+func init() {
+	resource.RegisterService(
+		navigation.API,
+		NavModel,
+		resource.Registration[navigation.Service, *NavConfig]{
+			Constructor: newNav,
+		})
+}
+
+// NavConfig is the config for the chartplotter navigation service.
+// MovementSensor is optional; when set, Location() reports the live
+// position/heading of that movement sensor.
+type NavConfig struct {
+	MovementSensor string `json:"movement_sensor,omitempty"`
+}
+
+// Validate ensures all parts of the config are valid and returns the
+// implicit dependencies required by the service.
+func (cfg *NavConfig) Validate(path string) ([]string, error) {
+	var deps []string
+	if cfg.MovementSensor != "" {
+		deps = append(deps, cfg.MovementSensor)
+	}
+	return deps, nil
+}
+
+func newNav(
+	ctx context.Context,
+	deps resource.Dependencies,
+	conf resource.Config,
+	logger logging.Logger,
+) (navigation.Service, error) {
+	cfg, err := resource.NativeConfig[*NavConfig](conf)
+	if err != nil {
+		return nil, err
+	}
+
+	svc := &navService{
+		name:   conf.ResourceName(),
+		logger: logger,
+		store:  navigation.NewMemoryNavigationStore(),
+	}
+	svc.mode.Store(uint32(navigation.ModeManual))
+
+	if cfg.MovementSensor != "" {
+		ms, err := movementsensor.FromDependencies(deps, cfg.MovementSensor)
+		if err != nil {
+			return nil, errors.Wrapf(err, "could not get movement_sensor %q", cfg.MovementSensor)
+		}
+		svc.ms = ms
+	}
+
+	return svc, nil
+}
+
+type navService struct {
+	resource.AlwaysRebuild
+
+	name   resource.Name
+	logger logging.Logger
+
+	mu    sync.Mutex
+	store navigation.NavStore
+	ms    movementsensor.MovementSensor
+
+	// mode is held atomically so reads don't need to take the mutex.
+	mode atomic.Uint32
+}
+
+func (s *navService) Name() resource.Name { return s.name }
+
+func (s *navService) Mode(ctx context.Context, extra map[string]interface{}) (navigation.Mode, error) {
+	return navigation.Mode(s.mode.Load()), nil
+}
+
+func (s *navService) SetMode(ctx context.Context, mode navigation.Mode, extra map[string]interface{}) error {
+	switch mode {
+	case navigation.ModeManual, navigation.ModeWaypoint, navigation.ModeExplore:
+	default:
+		return errors.Errorf("unknown navigation mode %v", mode)
+	}
+	s.mode.Store(uint32(mode))
+	return nil
+}
+
+func (s *navService) Location(ctx context.Context, extra map[string]interface{}) (*spatialmath.GeoPose, error) {
+	if s.ms == nil {
+		return spatialmath.NewGeoPose(geo.NewPoint(0, 0), 0), nil
+	}
+	pt, _, err := s.ms.Position(ctx, extra)
+	if err != nil {
+		return nil, err
+	}
+	heading, err := s.ms.CompassHeading(ctx, extra)
+	if err != nil {
+		// Heading may not be supported on every movement_sensor; fall back to 0.
+		heading = 0
+	}
+	return spatialmath.NewGeoPose(pt, heading), nil
+}
+
+func (s *navService) Waypoints(ctx context.Context, extra map[string]interface{}) ([]navigation.Waypoint, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.store.Waypoints(ctx)
+}
+
+func (s *navService) AddWaypoint(ctx context.Context, point *geo.Point, extra map[string]interface{}) error {
+	if point == nil {
+		return errors.New("waypoint location is required")
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	_, err := s.store.AddWaypoint(ctx, point)
+	return err
+}
+
+func (s *navService) RemoveWaypoint(ctx context.Context, id primitive.ObjectID, extra map[string]interface{}) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.store.RemoveWaypoint(ctx, id)
+}
+
+func (s *navService) Obstacles(ctx context.Context, extra map[string]interface{}) ([]*spatialmath.GeoGeometry, error) {
+	return nil, nil
+}
+
+func (s *navService) Paths(ctx context.Context, extra map[string]interface{}) ([]*navigation.Path, error) {
+	return nil, nil
+}
+
+func (s *navService) Properties(ctx context.Context) (navigation.Properties, error) {
+	return navigation.Properties{MapType: navigation.GPSMap}, nil
+}
+
+func (s *navService) DoCommand(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error) {
+	return nil, resource.ErrDoUnimplemented
+}
+
+func (s *navService) Close(ctx context.Context) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.store.Close(ctx)
+}

--- a/nav.go
+++ b/nav.go
@@ -2,6 +2,7 @@ package vc
 
 import (
 	"context"
+	"path/filepath"
 	"sync"
 	"sync/atomic"
 
@@ -30,8 +31,13 @@ func init() {
 // NavConfig is the config for the chartplotter navigation service.
 // MovementSensor is optional; when set, Location() reports the live
 // position/heading of that movement sensor.
+//
+// DataPath, when set, is used as the JSON file that mirrors the waypoint
+// list across restarts. When empty, waypoints persist to
+// "<user-cache-dir>/viam-chartplotter/nav/<resource_name>.json".
 type NavConfig struct {
 	MovementSensor string `json:"movement_sensor,omitempty"`
+	DataPath       string `json:"data_path,omitempty"`
 }
 
 // Validate ensures all parts of the config are valid and returns the
@@ -55,12 +61,22 @@ func newNav(
 		return nil, err
 	}
 
+	dataPath := cfg.DataPath
+	if dataPath == "" {
+		dataPath = filepath.Join(resolveCacheRoot(""), "nav", conf.ResourceName().Name+".json")
+	}
+	store, err := newDiskNavStore(dataPath)
+	if err != nil {
+		return nil, err
+	}
+
 	svc := &navService{
 		name:   conf.ResourceName(),
 		logger: logger,
-		store:  navigation.NewMemoryNavigationStore(),
+		store:  store,
 	}
 	svc.mode.Store(uint32(navigation.ModeManual))
+	logger.Infof("nav waypoints persisted at %s", dataPath)
 
 	if cfg.MovementSensor != "" {
 		ms, err := movementsensor.FromDependencies(deps, cfg.MovementSensor)

--- a/nav.go
+++ b/nav.go
@@ -170,16 +170,26 @@ func (s *navService) Properties(ctx context.Context) (navigation.Properties, err
 }
 
 // DoCommand exposes service-specific commands that don't have a first-class
-// gRPC method on the navigation API. Currently:
+// gRPC method on the navigation API:
 //
-//	{"move_waypoint": {"id": "<hex>", "lat": <float>, "lng": <float>}}
+//	{"move_waypoint":   {"id": "<hex>", "lat": <float>, "lng": <float>}}
+//	{"insert_waypoint": {"before_id": "<hex>", "lat": <float>, "lng": <float>}}
 //
-// updates an existing waypoint in place (preserving its ID and order).
+// move_waypoint updates an existing waypoint in place (preserving its ID and
+// order). insert_waypoint inserts a new waypoint immediately before the
+// waypoint with the given before_id; an empty/missing before_id is equivalent
+// to AddWayPoint (append).
 func (s *navService) DoCommand(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error) {
-	raw, ok := cmd["move_waypoint"]
-	if !ok {
-		return nil, resource.ErrDoUnimplemented
+	if raw, ok := cmd["move_waypoint"]; ok {
+		return s.doMoveWaypoint(ctx, raw)
 	}
+	if raw, ok := cmd["insert_waypoint"]; ok {
+		return s.doInsertWaypoint(ctx, raw)
+	}
+	return nil, resource.ErrDoUnimplemented
+}
+
+func (s *navService) doMoveWaypoint(ctx context.Context, raw interface{}) (map[string]interface{}, error) {
 	m, ok := raw.(map[string]interface{})
 	if !ok {
 		return nil, errors.New("move_waypoint payload must be an object")
@@ -209,6 +219,39 @@ func (s *navService) DoCommand(ctx context.Context, cmd map[string]interface{}) 
 		return nil, err
 	}
 	return map[string]interface{}{"ok": true}, nil
+}
+
+func (s *navService) doInsertWaypoint(ctx context.Context, raw interface{}) (map[string]interface{}, error) {
+	m, ok := raw.(map[string]interface{})
+	if !ok {
+		return nil, errors.New("insert_waypoint payload must be an object")
+	}
+	lat, latOK := m["lat"].(float64)
+	lng, lngOK := m["lng"].(float64)
+	if !latOK || !lngOK {
+		return nil, errors.New("insert_waypoint.lat and insert_waypoint.lng are required numbers")
+	}
+	var beforeID primitive.ObjectID
+	if idStr, _ := m["before_id"].(string); idStr != "" {
+		parsed, err := primitive.ObjectIDFromHex(idStr)
+		if err != nil {
+			return nil, errors.Wrapf(err, "invalid insert_waypoint.before_id %q", idStr)
+		}
+		beforeID = parsed
+	}
+	inserter, ok := s.store.(interface {
+		InsertWaypoint(ctx context.Context, point *geo.Point, beforeID primitive.ObjectID) (navigation.Waypoint, error)
+	})
+	if !ok {
+		return nil, errors.New("waypoint store does not support insert")
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	wp, err := inserter.InsertWaypoint(ctx, geo.NewPoint(lat, lng), beforeID)
+	if err != nil {
+		return nil, err
+	}
+	return map[string]interface{}{"ok": true, "id": wp.ID.Hex()}, nil
 }
 
 func (s *navService) Close(ctx context.Context) error {

--- a/nav.go
+++ b/nav.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	geo "github.com/kellydunn/golang-geo"
 	"github.com/pkg/errors"
@@ -35,9 +36,14 @@ func init() {
 // DataPath, when set, is used as the JSON file that mirrors the waypoint
 // list across restarts. When empty, waypoints persist to
 // "<user-cache-dir>/viam-chartplotter/nav/<resource_name>.json".
+//
+// ArrivalRadiusMeters controls auto-arrival: when MovementSensor is set, a
+// background poller marks the next waypoint visited as soon as the boat is
+// within this many meters of it. 0 disables auto-arrival; default is 200 m.
 type NavConfig struct {
-	MovementSensor string `json:"movement_sensor,omitempty"`
-	DataPath       string `json:"data_path,omitempty"`
+	MovementSensor      string  `json:"movement_sensor,omitempty"`
+	DataPath            string  `json:"data_path,omitempty"`
+	ArrivalRadiusMeters float64 `json:"arrival_radius_m,omitempty"`
 }
 
 // Validate ensures all parts of the config are valid and returns the
@@ -49,6 +55,15 @@ func (cfg *NavConfig) Validate(path string) ([]string, error) {
 	}
 	return deps, nil
 }
+
+// defaultArrivalRadiusMeters is the auto-arrival threshold used when the
+// config doesn't specify one. ~0.1 nm.
+const defaultArrivalRadiusMeters = 200.0
+
+// arrivalCheckInterval is how often the background poller re-checks distance
+// to the next waypoint. Cheap to compute, and 5 s is plenty for typical
+// boat speeds (~30 m at 12 kn, well under the default radius).
+const arrivalCheckInterval = 5 * time.Second
 
 func newNav(
 	ctx context.Context,
@@ -70,10 +85,16 @@ func newNav(
 		return nil, err
 	}
 
+	arrivalRadius := cfg.ArrivalRadiusMeters
+	if arrivalRadius == 0 {
+		arrivalRadius = defaultArrivalRadiusMeters
+	}
+
 	svc := &navService{
-		name:   conf.ResourceName(),
-		logger: logger,
-		store:  store,
+		name:                conf.ResourceName(),
+		logger:              logger,
+		store:               store,
+		arrivalRadiusMeters: arrivalRadius,
 	}
 	svc.mode.Store(uint32(navigation.ModeManual))
 	logger.Infof("nav waypoints persisted at %s", dataPath)
@@ -84,6 +105,10 @@ func newNav(
 			return nil, errors.Wrapf(err, "could not get movement_sensor %q", cfg.MovementSensor)
 		}
 		svc.ms = ms
+		if arrivalRadius > 0 {
+			svc.startArrivalPoller(arrivalRadius)
+			logger.Infof("nav auto-arrival enabled: %.0f m radius", arrivalRadius)
+		}
 	}
 
 	return svc, nil
@@ -101,6 +126,70 @@ type navService struct {
 
 	// mode is held atomically so reads don't need to take the mutex.
 	mode atomic.Uint32
+
+	arrivalRadiusMeters float64
+
+	// Cancellation for the background arrival poller, if started.
+	arrivalCancel context.CancelFunc
+	arrivalDone   chan struct{}
+}
+
+// startArrivalPoller launches a background goroutine that periodically
+// checks the boat's distance to the next unvisited waypoint and marks the
+// waypoint visited (so it disappears from Waypoints()) once the boat is
+// within radiusMeters.
+func (s *navService) startArrivalPoller(radiusMeters float64) {
+	ctx, cancel := context.WithCancel(context.Background())
+	s.arrivalCancel = cancel
+	s.arrivalDone = make(chan struct{})
+	radiusKm := radiusMeters / 1000.0
+	go func() {
+		defer close(s.arrivalDone)
+		ticker := time.NewTicker(arrivalCheckInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				s.checkArrival(ctx, radiusKm)
+			}
+		}
+	}()
+}
+
+// checkArrival is one tick of the arrival poller: pull the boat's position,
+// look up the next unvisited waypoint, and mark it visited if we're inside
+// the arrival radius. All errors are logged at debug level — the loop keeps
+// running so an intermittent GPS hiccup doesn't disable auto-arrival.
+func (s *navService) checkArrival(ctx context.Context, radiusKm float64) {
+	if s.ms == nil {
+		return
+	}
+	pt, _, err := s.ms.Position(ctx, nil)
+	if err != nil || pt == nil {
+		return
+	}
+	// Bail on null-island fixes; some movement sensors emit (0,0) before they
+	// have a lock and that would falsely "arrive" at any waypoint near it.
+	if pt.Lat() == 0 && pt.Lng() == 0 {
+		return
+	}
+	wps, err := s.store.Waypoints(ctx)
+	if err != nil || len(wps) == 0 {
+		return
+	}
+	next := wps[0]
+	dist := pt.GreatCircleDistance(geo.NewPoint(next.Lat, next.Long))
+	if dist > radiusKm {
+		return
+	}
+	if err := s.store.WaypointVisited(ctx, next.ID); err != nil {
+		s.logger.Debugw("WaypointVisited failed", "err", err)
+		return
+	}
+	s.logger.Infof("arrived at waypoint %s (%.0f m); marking visited",
+		next.ID.Hex(), dist*1000)
 }
 
 func (s *navService) Name() resource.Name { return s.name }
@@ -255,6 +344,14 @@ func (s *navService) doInsertWaypoint(ctx context.Context, raw interface{}) (map
 }
 
 func (s *navService) Close(ctx context.Context) error {
+	if s.arrivalCancel != nil {
+		s.arrivalCancel()
+		// Wait for the poller to exit so we don't race the store Close().
+		select {
+		case <-s.arrivalDone:
+		case <-ctx.Done():
+		}
+	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.store.Close(ctx)

--- a/nav_store.go
+++ b/nav_store.go
@@ -169,6 +169,36 @@ func (s *diskNavStore) RemoveWaypoint(ctx context.Context, id primitive.ObjectID
 	return nil
 }
 
+// MoveWaypoint updates the lat/long of an existing waypoint in place,
+// preserving its ID and order. It is not part of the upstream NavStore
+// interface; the chartplotter UI uses it (via DoCommand) to support
+// drag-to-edit on the map.
+func (s *diskNavStore) MoveWaypoint(ctx context.Context, id primitive.ObjectID, point *geo.Point) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if point == nil {
+		return errors.New("waypoint location is required")
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, wp := range s.waypoints {
+		if wp.ID != id {
+			continue
+		}
+		oldLat, oldLong := wp.Lat, wp.Long
+		wp.Lat = point.Lat()
+		wp.Long = point.Lng()
+		if err := s.save(); err != nil {
+			wp.Lat = oldLat
+			wp.Long = oldLong
+			return err
+		}
+		return nil
+	}
+	return errors.Errorf("no waypoint with id %s", id.Hex())
+}
+
 func (s *diskNavStore) NextWaypoint(ctx context.Context) (navigation.Waypoint, error) {
 	if err := ctx.Err(); err != nil {
 		return navigation.Waypoint{}, err

--- a/nav_store.go
+++ b/nav_store.go
@@ -169,6 +169,57 @@ func (s *diskNavStore) RemoveWaypoint(ctx context.Context, id primitive.ObjectID
 	return nil
 }
 
+// InsertWaypoint inserts a new waypoint immediately before the waypoint with
+// the given ID, preserving the order of every other waypoint. If beforeID is
+// the zero ObjectID the new waypoint is appended to the end (equivalent to
+// AddWaypoint). It is not part of the upstream NavStore interface; the
+// chartplotter UI uses it (via DoCommand) to "add waypoint here" between two
+// existing legs.
+func (s *diskNavStore) InsertWaypoint(
+	ctx context.Context,
+	point *geo.Point,
+	beforeID primitive.ObjectID,
+) (navigation.Waypoint, error) {
+	if err := ctx.Err(); err != nil {
+		return navigation.Waypoint{}, err
+	}
+	if point == nil {
+		return navigation.Waypoint{}, errors.New("waypoint location is required")
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	wp := &navigation.Waypoint{
+		ID:   primitive.NewObjectID(),
+		Lat:  point.Lat(),
+		Long: point.Lng(),
+	}
+	insertAt := len(s.waypoints)
+	if !beforeID.IsZero() {
+		found := false
+		for i, existing := range s.waypoints {
+			if existing.ID == beforeID {
+				insertAt = i
+				found = true
+				break
+			}
+		}
+		if !found {
+			return navigation.Waypoint{}, errors.Errorf("no waypoint with id %s", beforeID.Hex())
+		}
+	}
+	prev := s.waypoints
+	next := make([]*navigation.Waypoint, 0, len(prev)+1)
+	next = append(next, prev[:insertAt]...)
+	next = append(next, wp)
+	next = append(next, prev[insertAt:]...)
+	s.waypoints = next
+	if err := s.save(); err != nil {
+		s.waypoints = prev
+		return navigation.Waypoint{}, err
+	}
+	return *wp, nil
+}
+
 // MoveWaypoint updates the lat/long of an existing waypoint in place,
 // preserving its ID and order. It is not part of the upstream NavStore
 // interface; the chartplotter UI uses it (via DoCommand) to support

--- a/nav_store.go
+++ b/nav_store.go
@@ -26,12 +26,14 @@ type diskNavStore struct {
 // persistedWaypoint is the on-disk schema. We keep our own struct rather than
 // serialising navigation.Waypoint directly so the file stays human-friendly
 // (string ID, named lat/long fields) and decoupled from any future bson
-// changes upstream.
+// changes upstream. Visited waypoints stay on disk so the trip log survives
+// restarts; Waypoints() filters them out at read time.
 type persistedWaypoint struct {
-	ID    string  `json:"id"`
-	Lat   float64 `json:"lat"`
-	Long  float64 `json:"long"`
-	Order int     `json:"order,omitempty"`
+	ID      string  `json:"id"`
+	Lat     float64 `json:"lat"`
+	Long    float64 `json:"long"`
+	Order   int     `json:"order,omitempty"`
+	Visited bool    `json:"visited,omitempty"`
 }
 
 func newDiskNavStore(path string) (*diskNavStore, error) {
@@ -70,10 +72,11 @@ func (s *diskNavStore) load() error {
 			id = primitive.NewObjectID()
 		}
 		out = append(out, &navigation.Waypoint{
-			ID:    id,
-			Lat:   p.Lat,
-			Long:  p.Long,
-			Order: p.Order,
+			ID:      id,
+			Lat:     p.Lat,
+			Long:    p.Long,
+			Order:   p.Order,
+			Visited: p.Visited,
 		})
 	}
 	s.waypoints = out
@@ -91,10 +94,11 @@ func (s *diskNavStore) save() error {
 	out := make([]persistedWaypoint, 0, len(s.waypoints))
 	for _, wp := range s.waypoints {
 		out = append(out, persistedWaypoint{
-			ID:    wp.ID.Hex(),
-			Lat:   wp.Lat,
-			Long:  wp.Long,
-			Order: wp.Order,
+			ID:      wp.ID.Hex(),
+			Lat:     wp.Lat,
+			Long:    wp.Long,
+			Order:   wp.Order,
+			Visited: wp.Visited,
 		})
 	}
 	data, err := json.MarshalIndent(out, "", "  ")

--- a/nav_store.go
+++ b/nav_store.go
@@ -1,0 +1,207 @@
+package vc
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sync"
+
+	geo "github.com/kellydunn/golang-geo"
+	"github.com/pkg/errors"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+
+	"go.viam.com/rdk/services/navigation"
+)
+
+// diskNavStore is a navigation.NavStore that mirrors its waypoints to a JSON
+// file on disk so they survive module restarts. Every mutation rewrites the
+// file via a tmp+rename to avoid leaving a half-written file on crash.
+type diskNavStore struct {
+	mu        sync.Mutex
+	path      string
+	waypoints []*navigation.Waypoint
+}
+
+// persistedWaypoint is the on-disk schema. We keep our own struct rather than
+// serialising navigation.Waypoint directly so the file stays human-friendly
+// (string ID, named lat/long fields) and decoupled from any future bson
+// changes upstream.
+type persistedWaypoint struct {
+	ID    string  `json:"id"`
+	Lat   float64 `json:"lat"`
+	Long  float64 `json:"long"`
+	Order int     `json:"order,omitempty"`
+}
+
+func newDiskNavStore(path string) (*diskNavStore, error) {
+	s := &diskNavStore{path: path}
+	if err := s.load(); err != nil {
+		return nil, errors.Wrapf(err, "failed to load nav waypoints from %q", path)
+	}
+	return s, nil
+}
+
+func (s *diskNavStore) load() error {
+	if s.path == "" {
+		return nil
+	}
+	data, err := os.ReadFile(s.path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return err
+	}
+	if len(data) == 0 {
+		return nil
+	}
+	var raw []persistedWaypoint
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	out := make([]*navigation.Waypoint, 0, len(raw))
+	for _, p := range raw {
+		id, err := primitive.ObjectIDFromHex(p.ID)
+		if err != nil {
+			// Skip an unparseable ID rather than refusing to load the whole
+			// file; a stale waypoint is less disruptive than a refusal to
+			// start.
+			id = primitive.NewObjectID()
+		}
+		out = append(out, &navigation.Waypoint{
+			ID:    id,
+			Lat:   p.Lat,
+			Long:  p.Long,
+			Order: p.Order,
+		})
+	}
+	s.waypoints = out
+	return nil
+}
+
+// save flushes the current waypoint slice to disk. Caller must hold s.mu.
+func (s *diskNavStore) save() error {
+	if s.path == "" {
+		return nil
+	}
+	if err := os.MkdirAll(filepath.Dir(s.path), 0o755); err != nil {
+		return err
+	}
+	out := make([]persistedWaypoint, 0, len(s.waypoints))
+	for _, wp := range s.waypoints {
+		out = append(out, persistedWaypoint{
+			ID:    wp.ID.Hex(),
+			Lat:   wp.Lat,
+			Long:  wp.Long,
+			Order: wp.Order,
+		})
+	}
+	data, err := json.MarshalIndent(out, "", "  ")
+	if err != nil {
+		return err
+	}
+	tmp := s.path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o644); err != nil {
+		return err
+	}
+	return os.Rename(tmp, s.path)
+}
+
+func (s *diskNavStore) Waypoints(ctx context.Context) ([]navigation.Waypoint, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]navigation.Waypoint, 0, len(s.waypoints))
+	for _, wp := range s.waypoints {
+		if wp.Visited {
+			continue
+		}
+		out = append(out, *wp)
+	}
+	return out, nil
+}
+
+func (s *diskNavStore) AddWaypoint(ctx context.Context, point *geo.Point) (navigation.Waypoint, error) {
+	if err := ctx.Err(); err != nil {
+		return navigation.Waypoint{}, err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	wp := &navigation.Waypoint{
+		ID:   primitive.NewObjectID(),
+		Lat:  point.Lat(),
+		Long: point.Lng(),
+	}
+	s.waypoints = append(s.waypoints, wp)
+	if err := s.save(); err != nil {
+		// Roll back the in-memory append so disk and memory stay in sync.
+		s.waypoints = s.waypoints[:len(s.waypoints)-1]
+		return navigation.Waypoint{}, err
+	}
+	return *wp, nil
+}
+
+func (s *diskNavStore) RemoveWaypoint(ctx context.Context, id primitive.ObjectID) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	prev := s.waypoints
+	next := make([]*navigation.Waypoint, 0, len(prev))
+	for _, wp := range prev {
+		if wp.ID == id {
+			continue
+		}
+		next = append(next, wp)
+	}
+	if len(next) == len(prev) {
+		return nil
+	}
+	s.waypoints = next
+	if err := s.save(); err != nil {
+		s.waypoints = prev
+		return err
+	}
+	return nil
+}
+
+func (s *diskNavStore) NextWaypoint(ctx context.Context) (navigation.Waypoint, error) {
+	if err := ctx.Err(); err != nil {
+		return navigation.Waypoint{}, err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, wp := range s.waypoints {
+		if !wp.Visited {
+			return *wp, nil
+		}
+	}
+	return navigation.Waypoint{}, errors.New("no more waypoints")
+}
+
+func (s *diskNavStore) WaypointVisited(ctx context.Context, id primitive.ObjectID) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	changed := false
+	for _, wp := range s.waypoints {
+		if wp.ID == id && !wp.Visited {
+			wp.Visited = true
+			changed = true
+		}
+	}
+	if !changed {
+		return nil
+	}
+	return s.save()
+}
+
+func (s *diskNavStore) Close(ctx context.Context) error {
+	return nil
+}

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1333,6 +1333,31 @@
     }
   }
 
+  async function insertNavWaypoint(beforeId: string, lat: number, lng: number) {
+    if (!globalClient || !globalConfig.navServiceName) return;
+    try {
+      await new VIAM.NavigationClient(globalClient, globalConfig.navServiceName).doCommand(
+        VIAM.Struct.fromJson({ insert_waypoint: { before_id: beforeId, lat, lng } })
+      );
+      // Optimistically splice; the next poll will reconcile with the service.
+      const idx = beforeId
+        ? globalData.navWaypoints.findIndex((wp) => wp.id === beforeId)
+        : -1;
+      const placeholder = { id: `pending-${Date.now()}`, lat, lng };
+      if (idx >= 0) {
+        globalData.navWaypoints = [
+          ...globalData.navWaypoints.slice(0, idx),
+          placeholder,
+          ...globalData.navWaypoints.slice(idx),
+        ];
+      } else {
+        globalData.navWaypoints = [...globalData.navWaypoints, placeholder];
+      }
+    } catch (e) {
+      errorHandler(e, "insertWayPoint");
+    }
+  }
+
   async function moveNavWaypoint(id: string, lat: number, lng: number) {
     if (!globalClient || !globalConfig.navServiceName) return;
     if (!id || id.startsWith("pending-")) return;
@@ -1467,6 +1492,7 @@
       navWaypoints={globalData.navWaypoints}
       onAddWaypoint={globalConfig.navServiceName ? addNavWaypoint : undefined}
       onMoveWaypoint={globalConfig.navServiceName ? moveNavWaypoint : undefined}
+      onInsertWaypoint={globalConfig.navServiceName ? insertNavWaypoint : undefined}
       onClearWaypoints={globalConfig.navServiceName ? clearNavWaypoints : undefined}
     ></MarineMap>
 

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -69,6 +69,8 @@
     cameraNames: [],
     lastCameraTimes: [],
 
+    navWaypoints: [] as { id: string; lat: number; lng: number }[],
+
     numUpdates: 0,
     status: "Not connected yet",
     statusLastError: new Date(),
@@ -97,6 +99,7 @@
     movementSensorForQuery: "",
 
     aisSensorName: "",
+    navServiceName: "",
     routeSensorName: "",
     seatempSensorName: "",
     depthSensorName: "",
@@ -324,6 +327,24 @@
         });
     }
 
+    if (globalConfig.navServiceName != "") {
+      new VIAM.NavigationClient(client, globalConfig.navServiceName)
+        .getWayPoints()
+        .then((wps) => {
+          globalData.navWaypoints = (wps ?? [])
+            .filter((wp) => wp.location != null)
+            .map((wp) => ({
+              id: wp.id,
+              lat: wp.location!.latitude,
+              lng: wp.location!.longitude,
+            }));
+        })
+        .catch((e) => {
+          globalData.navWaypoints = [];
+          errorHandler(e, "navigation");
+        });
+    }
+
     if (loopNumber % 30 == 2) {
       globalData.allResources.forEach((r) => {
         if (r.subtype != "sensor") {
@@ -543,6 +564,12 @@
       "component",
       "sensor",
       /\bais$/
+    );
+    globalConfig.navServiceName = filterResourcesFirstMatchingName(
+      resources,
+      "service",
+      "navigation",
+      null
     );
     globalConfig.routeSensorName = filterResourcesFirstMatchingName(
       resources,
@@ -1286,6 +1313,52 @@
     return res;
   }
 
+  async function addNavWaypoint(lat: number, lng: number) {
+    if (!globalClient || !globalConfig.navServiceName) {
+      globalLogger.warn("no navigation service configured; cannot add waypoint");
+      return;
+    }
+    try {
+      await new VIAM.NavigationClient(globalClient, globalConfig.navServiceName).addWayPoint({
+        latitude: lat,
+        longitude: lng,
+      });
+      // Optimistically append; the next poll will reconcile with the service.
+      globalData.navWaypoints = [
+        ...globalData.navWaypoints,
+        { id: `pending-${Date.now()}`, lat, lng },
+      ];
+    } catch (e) {
+      errorHandler(e, "addWayPoint");
+    }
+  }
+
+  async function addNavWaypointFromCurrentPosition() {
+    var lat = globalData.pos.getLat();
+    var lng = globalData.pos.getLng();
+    if (lat === 0 && lng === 0) {
+      globalLogger.warn("no valid current position; cannot add waypoint");
+      return;
+    }
+    await addNavWaypoint(lat, lng);
+  }
+
+  async function clearNavWaypoints() {
+    if (!globalClient || !globalConfig.navServiceName) return;
+    var nav = new VIAM.NavigationClient(globalClient, globalConfig.navServiceName);
+    var existing = [...globalData.navWaypoints];
+    // Snap the local state immediately so the UI feels responsive.
+    globalData.navWaypoints = [];
+    for (var wp of existing) {
+      if (!wp.id || wp.id.startsWith("pending-")) continue;
+      try {
+        await nav.removeWayPoint(wp.id);
+      } catch (e) {
+        errorHandler(e, "removeWayPoint");
+      }
+    }
+  }
+
   function seakeeper(name, value) {
     var cmd = {};
     cmd[name] = value;
@@ -1385,7 +1458,19 @@
       depthColorTrack={globalData.showDepthOnTrack}
       defaultAisVisible={false}
       fullWidth={globalData.hideDataPanel}
+      navWaypoints={globalData.navWaypoints}
+      onAddWaypoint={globalConfig.navServiceName ? addNavWaypoint : undefined}
+      onClearWaypoints={globalConfig.navServiceName ? clearNavWaypoints : undefined}
     ></MarineMap>
+    {#if globalConfig.navServiceName}
+      <button
+        class="fixed top-2 right-[10rem] z-[10000] px-3 py-1 bg-black bg-opacity-60 border border-amber-500 hover:bg-amber-700 text-amber-300 rounded text-sm"
+        onclick={addNavWaypointFromCurrentPosition}
+        title="Add a waypoint at the current boat position"
+      >
+        + Route From Here
+      </button>
+    {/if}
 
     {#if !globalData.hideDataPanel}
     <aside class="lg:row-span-6 flex flex-col gap-4 border border-dark p-1 min-h-full text-white">

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1333,16 +1333,6 @@
     }
   }
 
-  async function addNavWaypointFromCurrentPosition() {
-    var lat = globalData.pos.getLat();
-    var lng = globalData.pos.getLng();
-    if (lat === 0 && lng === 0) {
-      globalLogger.warn("no valid current position; cannot add waypoint");
-      return;
-    }
-    await addNavWaypoint(lat, lng);
-  }
-
   async function moveNavWaypoint(id: string, lat: number, lng: number) {
     if (!globalClient || !globalConfig.navServiceName) return;
     if (!id || id.startsWith("pending-")) return;
@@ -1479,15 +1469,6 @@
       onMoveWaypoint={globalConfig.navServiceName ? moveNavWaypoint : undefined}
       onClearWaypoints={globalConfig.navServiceName ? clearNavWaypoints : undefined}
     ></MarineMap>
-    {#if globalConfig.navServiceName}
-      <button
-        class="fixed top-2 right-[10rem] z-[10000] px-3 py-1 bg-black bg-opacity-60 border border-amber-500 hover:bg-amber-700 text-amber-300 rounded text-sm"
-        onclick={addNavWaypointFromCurrentPosition}
-        title="Add a waypoint at the current boat position"
-      >
-        + Route From Here
-      </button>
-    {/if}
 
     {#if !globalData.hideDataPanel}
     <aside class="lg:row-span-6 flex flex-col gap-4 border border-dark p-1 min-h-full text-white">

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1374,6 +1374,18 @@
     }
   }
 
+  async function removeNavWaypoint(id: string) {
+    if (!globalClient || !globalConfig.navServiceName) return;
+    if (!id || id.startsWith("pending-")) return;
+    // Drop locally first so the marker disappears immediately.
+    globalData.navWaypoints = globalData.navWaypoints.filter((wp) => wp.id !== id);
+    try {
+      await new VIAM.NavigationClient(globalClient, globalConfig.navServiceName).removeWayPoint(id);
+    } catch (e) {
+      errorHandler(e, "removeWayPoint");
+    }
+  }
+
   async function clearNavWaypoints() {
     if (!globalClient || !globalConfig.navServiceName) return;
     var nav = new VIAM.NavigationClient(globalClient, globalConfig.navServiceName);
@@ -1493,6 +1505,7 @@
       onAddWaypoint={globalConfig.navServiceName ? addNavWaypoint : undefined}
       onMoveWaypoint={globalConfig.navServiceName ? moveNavWaypoint : undefined}
       onInsertWaypoint={globalConfig.navServiceName ? insertNavWaypoint : undefined}
+      onRemoveWaypoint={globalConfig.navServiceName ? removeNavWaypoint : undefined}
       onClearWaypoints={globalConfig.navServiceName ? clearNavWaypoints : undefined}
     ></MarineMap>
 

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1343,6 +1343,22 @@
     await addNavWaypoint(lat, lng);
   }
 
+  async function moveNavWaypoint(id: string, lat: number, lng: number) {
+    if (!globalClient || !globalConfig.navServiceName) return;
+    if (!id || id.startsWith("pending-")) return;
+    try {
+      await new VIAM.NavigationClient(globalClient, globalConfig.navServiceName).doCommand(
+        VIAM.Struct.fromJson({ move_waypoint: { id, lat, lng } })
+      );
+      // Optimistic local update; the next poll will reconcile.
+      globalData.navWaypoints = globalData.navWaypoints.map((wp) =>
+        wp.id === id ? { ...wp, lat, lng } : wp
+      );
+    } catch (e) {
+      errorHandler(e, "moveWayPoint");
+    }
+  }
+
   async function clearNavWaypoints() {
     if (!globalClient || !globalConfig.navServiceName) return;
     var nav = new VIAM.NavigationClient(globalClient, globalConfig.navServiceName);
@@ -1460,6 +1476,7 @@
       fullWidth={globalData.hideDataPanel}
       navWaypoints={globalData.navWaypoints}
       onAddWaypoint={globalConfig.navServiceName ? addNavWaypoint : undefined}
+      onMoveWaypoint={globalConfig.navServiceName ? moveNavWaypoint : undefined}
       onClearWaypoints={globalConfig.navServiceName ? clearNavWaypoints : undefined}
     ></MarineMap>
     {#if globalConfig.navServiceName}

--- a/src/marineMap.svelte
+++ b/src/marineMap.svelte
@@ -65,6 +65,8 @@
   let measureDistance = $state<number | null>(null);
   let measureSource: VectorSource | null = null;
 
+  let addWaypointActive = $state(false);
+
   const COOKIE_HEADS_UP = "mapHeadsUp";
   const COOKIE_LAYERS = "mapLayers";
   const COOKIE_HEADING_LINE_LENGTH = "mapHeadingLineLengthNm";
@@ -311,6 +313,9 @@
     showOfflineBoatsInPanel = true,
     defaultAisVisible = true,
     fullWidth = false,
+    navWaypoints,
+    onAddWaypoint,
+    onClearWaypoints,
     onReady,
     boatDetailSlot,
     fitBoundsPadding,
@@ -324,6 +329,13 @@
     depthColorTrack?: boolean;
     enableBoatsPanel?: boolean;
     fullWidth?: boolean;
+    /** Ordered waypoints from a navigation service. The route is drawn from the boat's
+     *  current position through each waypoint in order. */
+    navWaypoints?: { id: string; lat: number; lng: number }[];
+    /** Called when the user clicks the map while "add waypoint" mode is active. */
+    onAddWaypoint?: (lat: number, lng: number) => void;
+    /** Called when the user clicks the clear-route button. */
+    onClearWaypoints?: () => void;
     /** When true, parent controls visibility via setVisibleBoats API instead of auto-showing new boats */
     externalVisibilityControl?: boolean;
     /** When false, offline boats are hidden from the boats panel (default: true) */
@@ -352,6 +364,7 @@
   let myBoatKey = $derived(
     myBoat ? JSON.stringify([myBoat.heading, myBoat.location, myBoat.speed, myBoat.route]) : null
   );
+  let navWaypointsKey = $derived(JSON.stringify(navWaypoints ?? []));
   let visibleBoatsKey = $derived(JSON.stringify([...visibleBoats]));
   let effectiveVisibleKey = $derived(JSON.stringify([...effectiveVisibleBoats]));
 
@@ -360,6 +373,7 @@
     const _boats = boatsKey;
     const _myBoat = myBoatKey;
     const _visible = visibleBoatsKey;
+    const _wps = navWaypointsKey;
     updateFromData();
   });
 
@@ -435,6 +449,7 @@
     trackFeatures: new Collection<Feature<Geometry>>(),
     aisTrackFeatures: new Collection<Feature<Geometry>>(),
     routeFeatures: new Collection<Feature<Geometry>>(),
+    navRouteFeatures: new Collection<Feature<Geometry>>(),
     headingLineFeatures: new Collection<Feature<Geometry>>(),
     trackFeaturesLastCheck: new Date(0),
     myBoatMarker: null as Feature<Point> | null,
@@ -541,6 +556,35 @@
         geometry: new LineString([mapInternalState.lastPosition, dest]),
       });
       mapGlobal.routeFeatures.push(f);
+    }
+
+    // navigation-service route: draws a polyline from the boat through each
+    // waypoint in order, plus a circle marker at every waypoint.
+    mapGlobal.navRouteFeatures.clear();
+    if (navWaypoints && navWaypoints.length > 0) {
+      const wpCoords: number[][] = navWaypoints.map((wp) => [wp.lng, wp.lat]);
+
+      const startCoord =
+        myBoat && isValidCoordinate(myBoat.location[0], myBoat.location[1])
+          ? [myBoat.location[1], myBoat.location[0]]
+          : null;
+      const lineCoords = startCoord ? [startCoord, ...wpCoords] : wpCoords;
+
+      if (lineCoords.length >= 2) {
+        mapGlobal.navRouteFeatures.push(
+          new Feature({ type: "navRoute", geometry: new LineString(lineCoords) })
+        );
+      }
+      navWaypoints.forEach((wp, idx) => {
+        mapGlobal.navRouteFeatures.push(
+          new Feature({
+            type: "navWaypoint",
+            waypointId: wp.id,
+            waypointIndex: idx,
+            geometry: new Point([wp.lng, wp.lat]),
+          })
+        );
+      });
     }
 
     if (boats == null) {
@@ -955,6 +999,7 @@
       measurePoints = [];
       measureDistance = null;
       if (measureSource) measureSource.clear();
+      addWaypointActive = false;
       closePopup();
     }
   }
@@ -964,6 +1009,21 @@
     measurePoints = [];
     measureDistance = null;
     if (measureSource) measureSource.clear();
+  }
+
+  function toggleAddWaypoint() {
+    if (!onAddWaypoint) return;
+    addWaypointActive = !addWaypointActive;
+    if (addWaypointActive) {
+      // Mutually exclusive with measure mode.
+      if (measureActive) stopMeasure();
+      closePopup();
+    }
+  }
+
+  function clearWaypoints() {
+    addWaypointActive = false;
+    onClearWaypoints?.();
   }
 
   function toggleHeadsUp() {
@@ -1303,6 +1363,40 @@
         layer: routeLayer,
         parent: "boat", // Route is a child of boat layer
       });
+
+      // Nav-service route: line + waypoint markers driven by `navWaypoints`.
+      var navRouteLayer = new Vector({
+        source: new VectorSource({
+          features: mapGlobal.navRouteFeatures,
+        }),
+        style: function (feature) {
+          if (feature.get("type") === "navWaypoint") {
+            return new Style({
+              image: new CircleStyle({
+                radius: 7,
+                fill: new Fill({ color: "#f59e0b" }),
+                stroke: new Stroke({ color: "white", width: 2 }),
+              }),
+            });
+          }
+          return new Style({
+            stroke: new Stroke({
+              color: "#f59e0b",
+              width: 3,
+              lineDash: [10, 6],
+            }),
+          });
+        },
+        zIndex: 21,
+      });
+
+      mapGlobal.layerOptions.push({
+        name: "nav-route",
+        displayName: "nav route",
+        on: true,
+        layer: navRouteLayer,
+        parent: "boat",
+      });
     }
 
     var aisLayer = new Vector({
@@ -1524,6 +1618,11 @@
         handleMeasureClick(evt);
         return;
       }
+      if (addWaypointActive && onAddWaypoint) {
+        const [lng, lat] = evt.coordinate;
+        onAddWaypoint(lat, lng);
+        return;
+      }
       const feature = mapGlobal.map!.forEachFeatureAtPixel(evt.pixel, function (f) {
         const type = f.get("type");
         if (type === "ais" || type === "geoMarker" || type === "detection") {
@@ -1604,11 +1703,8 @@
           );
         },
       });
-      mapGlobal.map!.getTargetElement()!.style.cursor = measureActive
-        ? "crosshair"
-        : hit
-          ? "pointer"
-          : "";
+      mapGlobal.map!.getTargetElement()!.style.cursor =
+        measureActive || addWaypointActive ? "crosshair" : hit ? "pointer" : "";
 
       // Depth tooltip on track hover
       let depthFound = false;
@@ -2021,6 +2117,45 @@
       /></svg
     >
   </button>
+
+  {#if onAddWaypoint}
+    <button
+      class="add-waypoint-toggle"
+      class:active={addWaypointActive}
+      onclick={toggleAddWaypoint}
+      aria-pressed={addWaypointActive}
+      title={addWaypointActive
+        ? "Click on the chart to add a waypoint (active)"
+        : "Add a route waypoint from current position"}
+      aria-label="Add waypoint"
+    >
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="15"
+        height="15"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        aria-hidden="true"
+      >
+        <path d="M12 21s-7-7.5-7-12a7 7 0 0 1 14 0c0 4.5-7 12-7 12Z" />
+        <circle cx="12" cy="9" r="2.5" />
+      </svg>
+    </button>
+    {#if navWaypoints && navWaypoints.length > 0}
+      <button
+        class="clear-waypoints-btn"
+        onclick={clearWaypoints}
+        title="Clear all route waypoints"
+        aria-label="Clear route"
+      >
+        ✕
+      </button>
+    {/if}
+  {/if}
 
   <button
     class="heads-up-toggle"
@@ -2459,6 +2594,68 @@
     background: #1d4ed8;
   }
 
+  /* Add-waypoint toggle: sits to the left of the boat-position toggle. */
+  .add-waypoint-toggle {
+    position: absolute;
+    top: 10px;
+    right: calc(10px + 30px + 6px + 30px + 6px + 30px + 6px);
+    width: 30px;
+    height: 30px;
+    padding: 0;
+    background: rgba(255, 255, 255, 0.95);
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    cursor: pointer;
+    color: #333;
+    box-shadow: 0 1px 4px rgba(0, 0, 0, 0.2);
+    z-index: 1001;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .add-waypoint-toggle:hover {
+    background: white;
+    border-color: #999;
+  }
+
+  .add-waypoint-toggle.active {
+    background: #f59e0b;
+    color: white;
+    border-color: #b45309;
+  }
+
+  .add-waypoint-toggle.active:hover {
+    background: #d97706;
+  }
+
+  /* Sits directly below the add-waypoint toggle when waypoints exist. */
+  .clear-waypoints-btn {
+    position: absolute;
+    top: calc(10px + 30px + 6px);
+    right: calc(10px + 30px + 6px + 30px + 6px + 30px + 6px);
+    width: 30px;
+    height: 30px;
+    padding: 0;
+    background: rgba(255, 255, 255, 0.95);
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    cursor: pointer;
+    color: #b45309;
+    font-size: 14px;
+    font-weight: bold;
+    box-shadow: 0 1px 4px rgba(0, 0, 0, 0.2);
+    z-index: 1001;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .clear-waypoints-btn:hover {
+    background: #fef3c7;
+    border-color: #b45309;
+  }
+
   /* When the data panel is hidden, the map is full-width and its top-right
      buttons collide with the page-level fullscreen / drawer-toggle buttons.
      Shift the map's top-right cluster left to clear them. */
@@ -2470,6 +2667,12 @@
   }
   #map-container.full-width .boat-position-toggle {
     right: calc(10px + 30px + 6px + 30px + 6px + 85px);
+  }
+  #map-container.full-width .add-waypoint-toggle {
+    right: calc(10px + 30px + 6px + 30px + 6px + 30px + 6px + 85px);
+  }
+  #map-container.full-width .clear-waypoints-btn {
+    right: calc(10px + 30px + 6px + 30px + 6px + 30px + 6px + 85px);
   }
   #map-container.full-width .measure-result {
     right: calc(10px + 85px);

--- a/src/marineMap.svelte
+++ b/src/marineMap.svelte
@@ -55,15 +55,18 @@
     },
   });
 
-  // Popup shown when the user clicks a route segment in edit mode. Offers a
-  // single "add waypoint here" action that inserts a new waypoint between the
-  // segment's two endpoints.
-  let insertPopupState = $state({
+  // Popup shown when the user clicks a waypoint or a route segment in edit
+  // mode. Mode "insert" offers "add waypoint here" between two existing
+  // waypoints; mode "delete" offers "delete this waypoint" for the clicked
+  // marker.
+  let editPopupState = $state({
     overlay: null as Overlay | null,
     visible: false,
+    mode: "insert" as "insert" | "delete",
     lat: 0,
     lng: 0,
-    beforeId: "",
+    // For "insert": the waypoint to slot before. For "delete": the waypoint to remove.
+    waypointId: "",
   });
 
   let layersExpanded = $state(false);
@@ -400,6 +403,7 @@
     onAddWaypoint,
     onMoveWaypoint,
     onInsertWaypoint,
+    onRemoveWaypoint,
     onClearWaypoints,
     onReady,
     boatDetailSlot,
@@ -425,6 +429,8 @@
      *  beforeId is the ID of the waypoint the new one should sort before;
      *  empty string means "append to the end of the route". */
     onInsertWaypoint?: (beforeId: string, lat: number, lng: number) => void;
+    /** Called when the user picks "delete this waypoint" on an existing marker. */
+    onRemoveWaypoint?: (id: string) => void;
     /** Called when the user clicks the clear-route button. */
     onClearWaypoints?: () => void;
     /** When true, parent controls visibility via setVisibleBoats API instead of auto-showing new boats */
@@ -1189,8 +1195,8 @@
     } else if ((!addWaypointActive || !onMoveWaypoint) && waypointModifyInteraction) {
       uninstallWaypointModify();
     }
-    if (!addWaypointActive && insertPopupState.visible) {
-      closeInsertPopup();
+    if (!addWaypointActive && editPopupState.visible) {
+      closeEditPopup();
     }
   });
 
@@ -1257,23 +1263,31 @@
     return Math.sqrt(ex * ex + ey * ey);
   }
 
-  function showInsertPopup(coord: number[], beforeId: string) {
-    insertPopupState.lng = coord[0];
-    insertPopupState.lat = coord[1];
-    insertPopupState.beforeId = beforeId;
-    insertPopupState.visible = true;
-    insertPopupState.overlay?.setPosition(coord);
+  function showEditPopup(
+    mode: "insert" | "delete",
+    coord: number[],
+    waypointId: string
+  ) {
+    editPopupState.mode = mode;
+    editPopupState.lng = coord[0];
+    editPopupState.lat = coord[1];
+    editPopupState.waypointId = waypointId;
+    editPopupState.visible = true;
+    editPopupState.overlay?.setPosition(coord);
   }
 
-  function closeInsertPopup() {
-    insertPopupState.visible = false;
-    insertPopupState.overlay?.setPosition(undefined);
+  function closeEditPopup() {
+    editPopupState.visible = false;
+    editPopupState.overlay?.setPosition(undefined);
   }
 
-  function confirmInsertWaypoint() {
-    if (!onInsertWaypoint) return;
-    onInsertWaypoint(insertPopupState.beforeId, insertPopupState.lat, insertPopupState.lng);
-    closeInsertPopup();
+  function confirmEditPopup() {
+    if (editPopupState.mode === "insert") {
+      onInsertWaypoint?.(editPopupState.waypointId, editPopupState.lat, editPopupState.lng);
+    } else {
+      onRemoveWaypoint?.(editPopupState.waypointId);
+    }
+    closeEditPopup();
   }
 
   function toggleHeadsUp() {
@@ -1859,17 +1873,17 @@
     });
     mapGlobal.map.addOverlay(popupState.overlay);
 
-    // Setup insert-waypoint popup overlay (single button, anchored above the
-    // clicked spot on the route line).
-    const insertEl = document.getElementById("insert-waypoint-popup");
-    insertPopupState.overlay = new Overlay({
-      element: insertEl || undefined,
+    // Setup edit popup overlay (single popup, anchored above the clicked
+    // spot on the route line or a waypoint marker).
+    const editPopupEl = document.getElementById("edit-waypoint-popup");
+    editPopupState.overlay = new Overlay({
+      element: editPopupEl || undefined,
       autoPan: false,
       positioning: "bottom-center",
-      offset: [0, -10],
+      offset: [0, -14],
       stopEvent: true,
     });
-    mapGlobal.map.addOverlay(insertPopupState.overlay);
+    mapGlobal.map.addOverlay(editPopupState.overlay);
 
     // Setup depth tooltip overlay
     const depthTooltipElement = document.getElementById("depth-tooltip");
@@ -1894,32 +1908,56 @@
         return;
       }
       if (addWaypointActive && onAddWaypoint) {
-        // Prefer "insert between two waypoints" if the user clicked on the
-        // route line; otherwise fall through to the append behaviour.
-        if (onInsertWaypoint && navWaypoints && navWaypoints.length > 0) {
-          const lineFeature = mapGlobal.map!.forEachFeatureAtPixel(
-            evt.pixel,
-            (f) => (f.get("type") === "navRoute" ? (f as Feature<LineString>) : null),
-            { hitTolerance: 8 }
-          ) as Feature<LineString> | undefined;
-          if (lineFeature) {
-            const geom = lineFeature.getGeometry();
-            const segIds = lineFeature.get("segmentBeforeIds") as string[] | undefined;
-            if (geom && segIds && segIds.length > 0) {
-              const segIdx = closestSegmentIndex(geom.getCoordinates(), evt.coordinate);
-              const beforeId = segIds[Math.max(0, Math.min(segIds.length - 1, segIdx))];
-              showInsertPopup(evt.coordinate, beforeId);
-              return;
+        // Hit-test in priority order: existing waypoint marker → route line →
+        // empty water. Iterate features ourselves so we can find the *first*
+        // marker AND the *first* line under the pixel without re-querying.
+        let waypointFeature: Feature<Point> | null = null;
+        let lineFeature: Feature<LineString> | null = null;
+        mapGlobal.map!.forEachFeatureAtPixel(
+          evt.pixel,
+          (f) => {
+            const t = f.get("type");
+            if (!waypointFeature && t === "navWaypoint") {
+              waypointFeature = f as Feature<Point>;
+            } else if (!lineFeature && t === "navRoute") {
+              lineFeature = f as Feature<LineString>;
             }
+            // Stop early once we have both potential candidates.
+            return waypointFeature && lineFeature ? true : undefined;
+          },
+          { hitTolerance: 8 }
+        );
+
+        if (waypointFeature && onRemoveWaypoint) {
+          const wpFeat = waypointFeature as Feature<Point>;
+          const id = wpFeat.get("waypointId") as string;
+          const geom = wpFeat.getGeometry();
+          if (id && geom) {
+            showEditPopup("delete", geom.getCoordinates(), id);
+            return;
           }
         }
+
+        if (lineFeature && onInsertWaypoint && navWaypoints && navWaypoints.length > 0) {
+          const lineFeat = lineFeature as Feature<LineString>;
+          const geom = lineFeat.getGeometry();
+          const segIds = lineFeat.get("segmentBeforeIds") as string[] | undefined;
+          if (geom && segIds && segIds.length > 0) {
+            const segIdx = closestSegmentIndex(geom.getCoordinates(), evt.coordinate);
+            const beforeId = segIds[Math.max(0, Math.min(segIds.length - 1, segIdx))];
+            showEditPopup("insert", evt.coordinate, beforeId);
+            return;
+          }
+        }
+
+        // Empty water in edit mode: append to the end of the route.
         const [lng, lat] = evt.coordinate;
         onAddWaypoint(lat, lng);
         return;
       }
-      // Clicking outside any feature dismisses the insert popup if it's open.
-      if (insertPopupState.visible) {
-        closeInsertPopup();
+      // Clicking outside any feature dismisses the edit popup if it's open.
+      if (editPopupState.visible) {
+        closeEditPopup();
       }
       const feature = mapGlobal.map!.forEachFeatureAtPixel(evt.pixel, function (f) {
         const type = f.get("type");
@@ -2239,16 +2277,27 @@
   <!-- Depth Tooltip -->
   <div id="depth-tooltip" class="depth-tooltip"></div>
 
-  <!-- Insert-waypoint popup. Shown when the user clicks on a route segment in
-       edit mode. The element must always exist for OL's Overlay to bind to;
-       visibility is driven by class="hidden". -->
+  <!-- Edit popup. Shown when the user clicks a waypoint or a route segment
+       in edit mode. The element must always exist for OL's Overlay to bind
+       to; visibility is driven by class="hidden". -->
   <div
-    id="insert-waypoint-popup"
-    class="insert-waypoint-popup"
-    class:hidden={!insertPopupState.visible}
+    id="edit-waypoint-popup"
+    class="edit-waypoint-popup"
+    class:hidden={!editPopupState.visible}
+    class:delete={editPopupState.mode === "delete"}
   >
-    <button class="insert-waypoint-btn" onclick={confirmInsertWaypoint}>+ Add waypoint here</button>
-    <button class="insert-waypoint-close" onclick={closeInsertPopup} aria-label="Cancel">✕</button>
+    <button
+      class="edit-waypoint-btn"
+      class:delete={editPopupState.mode === "delete"}
+      onclick={confirmEditPopup}
+    >
+      {#if editPopupState.mode === "delete"}
+        Delete this waypoint
+      {:else}
+        + Add waypoint here
+      {/if}
+    </button>
+    <button class="edit-waypoint-close" onclick={closeEditPopup} aria-label="Cancel">✕</button>
   </div>
 
   {#if inPanMode}
@@ -3031,7 +3080,7 @@
     white-space: nowrap;
   }
 
-  .insert-waypoint-popup {
+  .edit-waypoint-popup {
     display: flex;
     gap: 4px;
     align-items: center;
@@ -3048,11 +3097,15 @@
       sans-serif;
   }
 
-  .insert-waypoint-popup.hidden {
+  .edit-waypoint-popup.delete {
+    border-color: #dc2626;
+  }
+
+  .edit-waypoint-popup.hidden {
     display: none;
   }
 
-  .insert-waypoint-btn {
+  .edit-waypoint-btn {
     background: #f59e0b;
     color: #1f2937;
     border: none;
@@ -3063,11 +3116,20 @@
     cursor: pointer;
   }
 
-  .insert-waypoint-btn:hover {
+  .edit-waypoint-btn:hover {
     background: #d97706;
   }
 
-  .insert-waypoint-close {
+  .edit-waypoint-btn.delete {
+    background: #dc2626;
+    color: white;
+  }
+
+  .edit-waypoint-btn.delete:hover {
+    background: #b91c1c;
+  }
+
+  .edit-waypoint-close {
     background: transparent;
     color: #fde68a;
     border: none;
@@ -3076,7 +3138,7 @@
     font-size: 12px;
   }
 
-  .insert-waypoint-close:hover {
+  .edit-waypoint-close:hover {
     color: white;
   }
 

--- a/src/marineMap.svelte
+++ b/src/marineMap.svelte
@@ -1133,22 +1133,30 @@
   // dragged we leave it untouched so the drag can finish cleanly.
   function syncNavWaypointFeatures() {
     const desired = navWaypoints ?? [];
-    const desiredById = new Map(desired.map((wp) => [wp.id, wp]));
+    // Plain object lookup by id; the OL `Map` import shadows the global
+    // Map constructor in this module, so `new Map(...)` would build a map
+    // widget instead of a hash and blow up on `.has(...)`.
+    const desiredById: Record<string, true> = {};
+    for (const wp of desired) {
+      desiredById[wp.id] = true;
+    }
 
     const features = mapGlobal.navWaypointFeatures;
     for (let i = features.getLength() - 1; i >= 0; i--) {
       const feat = features.item(i) as Feature<Point>;
       const id = feat.get("waypointId") as string;
-      if (!desiredById.has(id) && id !== draggingWaypointId) {
+      if (!desiredById[id] && id !== draggingWaypointId) {
         features.removeAt(i);
       }
     }
 
-    const existingById = new Map<string, Feature<Point>>();
-    features.forEach((f) => existingById.set(f.get("waypointId") as string, f as Feature<Point>));
+    const existingById: Record<string, Feature<Point>> = {};
+    features.forEach((f) => {
+      existingById[f.get("waypointId") as string] = f as Feature<Point>;
+    });
 
     desired.forEach((wp, idx) => {
-      const existing = existingById.get(wp.id);
+      const existing = existingById[wp.id];
       if (existing) {
         if (wp.id !== draggingWaypointId) {
           existing.setGeometry(new Point([wp.lng, wp.lat]));

--- a/src/marineMap.svelte
+++ b/src/marineMap.svelte
@@ -55,6 +55,17 @@
     },
   });
 
+  // Popup shown when the user clicks a route segment in edit mode. Offers a
+  // single "add waypoint here" action that inserts a new waypoint between the
+  // segment's two endpoints.
+  let insertPopupState = $state({
+    overlay: null as Overlay | null,
+    visible: false,
+    lat: 0,
+    lng: 0,
+    beforeId: "",
+  });
+
   let layersExpanded = $state(false);
   let boatsExpanded = $state(false);
   let mapLoaded = $state(false);
@@ -388,6 +399,7 @@
     navWaypoints,
     onAddWaypoint,
     onMoveWaypoint,
+    onInsertWaypoint,
     onClearWaypoints,
     onReady,
     boatDetailSlot,
@@ -409,6 +421,10 @@
     onAddWaypoint?: (lat: number, lng: number) => void;
     /** Called when the user finishes dragging an existing waypoint. */
     onMoveWaypoint?: (id: string, lat: number, lng: number) => void;
+    /** Called when the user picks "add waypoint here" on a route segment.
+     *  beforeId is the ID of the waypoint the new one should sort before;
+     *  empty string means "append to the end of the route". */
+    onInsertWaypoint?: (beforeId: string, lat: number, lng: number) => void;
     /** Called when the user clicks the clear-route button. */
     onClearWaypoints?: () => void;
     /** When true, parent controls visibility via setVisibleBoats API instead of auto-showing new boats */
@@ -650,8 +666,22 @@
       const lineCoords = startCoord ? [startCoord, ...wpCoords] : wpCoords;
 
       if (lineCoords.length >= 2) {
+        // Each segment ends at the waypoint with this ID. When the user picks
+        // "add waypoint here" on segment i the new wp is inserted *before*
+        // this id, which keeps the segment's right endpoint stable.
+        const segmentBeforeIds: string[] = [];
+        for (let i = 1; i < lineCoords.length; i++) {
+          // line index i corresponds to wp index (i - offset) where offset is
+          // 1 if the line starts at the boat, 0 otherwise.
+          const wpIdx = startCoord ? i - 1 : i;
+          segmentBeforeIds.push(navWaypoints[wpIdx].id);
+        }
         mapGlobal.navRouteLineFeatures.push(
-          new Feature({ type: "navRoute", geometry: new LineString(lineCoords) })
+          new Feature({
+            type: "navRoute",
+            segmentBeforeIds,
+            geometry: new LineString(lineCoords),
+          })
         );
       }
     }
@@ -1151,6 +1181,9 @@
     } else if ((!addWaypointActive || !onMoveWaypoint) && waypointModifyInteraction) {
       uninstallWaypointModify();
     }
+    if (!addWaypointActive && insertPopupState.visible) {
+      closeInsertPopup();
+    }
   });
 
   function installWaypointModify() {
@@ -1184,6 +1217,55 @@
     }
     waypointModifyInteraction = null;
     draggingWaypointId = null;
+  }
+
+  // Returns the index of the segment in `coords` (i.e. the segment from
+  // coords[i] to coords[i+1]) that lies closest to `pt`. Distances are in the
+  // map's projected units, which is fine for "which one did I click" — we
+  // only care about the relative ordering, not absolute meters.
+  function closestSegmentIndex(coords: number[][], pt: number[]): number {
+    let best = -1;
+    let bestDist = Infinity;
+    for (let i = 0; i < coords.length - 1; i++) {
+      const d = pointSegmentDist(pt, coords[i], coords[i + 1]);
+      if (d < bestDist) {
+        bestDist = d;
+        best = i;
+      }
+    }
+    return best;
+  }
+
+  function pointSegmentDist(p: number[], a: number[], b: number[]): number {
+    const dx = b[0] - a[0];
+    const dy = b[1] - a[1];
+    const lenSq = dx * dx + dy * dy;
+    let t = lenSq === 0 ? 0 : ((p[0] - a[0]) * dx + (p[1] - a[1]) * dy) / lenSq;
+    t = Math.max(0, Math.min(1, t));
+    const cx = a[0] + t * dx;
+    const cy = a[1] + t * dy;
+    const ex = p[0] - cx;
+    const ey = p[1] - cy;
+    return Math.sqrt(ex * ex + ey * ey);
+  }
+
+  function showInsertPopup(coord: number[], beforeId: string) {
+    insertPopupState.lng = coord[0];
+    insertPopupState.lat = coord[1];
+    insertPopupState.beforeId = beforeId;
+    insertPopupState.visible = true;
+    insertPopupState.overlay?.setPosition(coord);
+  }
+
+  function closeInsertPopup() {
+    insertPopupState.visible = false;
+    insertPopupState.overlay?.setPosition(undefined);
+  }
+
+  function confirmInsertWaypoint() {
+    if (!onInsertWaypoint) return;
+    onInsertWaypoint(insertPopupState.beforeId, insertPopupState.lat, insertPopupState.lng);
+    closeInsertPopup();
   }
 
   function toggleHeadsUp() {
@@ -1769,6 +1851,18 @@
     });
     mapGlobal.map.addOverlay(popupState.overlay);
 
+    // Setup insert-waypoint popup overlay (single button, anchored above the
+    // clicked spot on the route line).
+    const insertEl = document.getElementById("insert-waypoint-popup");
+    insertPopupState.overlay = new Overlay({
+      element: insertEl || undefined,
+      autoPan: false,
+      positioning: "bottom-center",
+      offset: [0, -10],
+      stopEvent: true,
+    });
+    mapGlobal.map.addOverlay(insertPopupState.overlay);
+
     // Setup depth tooltip overlay
     const depthTooltipElement = document.getElementById("depth-tooltip");
     const depthTooltipOverlay = new Overlay({
@@ -1792,9 +1886,32 @@
         return;
       }
       if (addWaypointActive && onAddWaypoint) {
+        // Prefer "insert between two waypoints" if the user clicked on the
+        // route line; otherwise fall through to the append behaviour.
+        if (onInsertWaypoint && navWaypoints && navWaypoints.length > 0) {
+          const lineFeature = mapGlobal.map!.forEachFeatureAtPixel(
+            evt.pixel,
+            (f) => (f.get("type") === "navRoute" ? (f as Feature<LineString>) : null),
+            { hitTolerance: 8 }
+          ) as Feature<LineString> | undefined;
+          if (lineFeature) {
+            const geom = lineFeature.getGeometry();
+            const segIds = lineFeature.get("segmentBeforeIds") as string[] | undefined;
+            if (geom && segIds && segIds.length > 0) {
+              const segIdx = closestSegmentIndex(geom.getCoordinates(), evt.coordinate);
+              const beforeId = segIds[Math.max(0, Math.min(segIds.length - 1, segIdx))];
+              showInsertPopup(evt.coordinate, beforeId);
+              return;
+            }
+          }
+        }
         const [lng, lat] = evt.coordinate;
         onAddWaypoint(lat, lng);
         return;
+      }
+      // Clicking outside any feature dismisses the insert popup if it's open.
+      if (insertPopupState.visible) {
+        closeInsertPopup();
       }
       const feature = mapGlobal.map!.forEachFeatureAtPixel(evt.pixel, function (f) {
         const type = f.get("type");
@@ -2113,6 +2230,18 @@
 
   <!-- Depth Tooltip -->
   <div id="depth-tooltip" class="depth-tooltip"></div>
+
+  <!-- Insert-waypoint popup. Shown when the user clicks on a route segment in
+       edit mode. The element must always exist for OL's Overlay to bind to;
+       visibility is driven by class="hidden". -->
+  <div
+    id="insert-waypoint-popup"
+    class="insert-waypoint-popup"
+    class:hidden={!insertPopupState.visible}
+  >
+    <button class="insert-waypoint-btn" onclick={confirmInsertWaypoint}>+ Add waypoint here</button>
+    <button class="insert-waypoint-close" onclick={closeInsertPopup} aria-label="Cancel">✕</button>
+  </div>
 
   {#if inPanMode}
     <button class="stop-panning-btn" onclick={stopPanning}>Stop Panning</button>
@@ -2892,6 +3021,55 @@
     box-shadow: 0 1px 4px rgba(0, 0, 0, 0.3);
     z-index: 1000;
     white-space: nowrap;
+  }
+
+  .insert-waypoint-popup {
+    display: flex;
+    gap: 4px;
+    align-items: center;
+    background: rgba(15, 23, 42, 0.95);
+    border: 1px solid #f59e0b;
+    border-radius: 6px;
+    padding: 4px;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.4);
+    z-index: 1002;
+    white-space: nowrap;
+    font-family:
+      system-ui,
+      -apple-system,
+      sans-serif;
+  }
+
+  .insert-waypoint-popup.hidden {
+    display: none;
+  }
+
+  .insert-waypoint-btn {
+    background: #f59e0b;
+    color: #1f2937;
+    border: none;
+    border-radius: 4px;
+    padding: 4px 10px;
+    font-size: 12px;
+    font-weight: 600;
+    cursor: pointer;
+  }
+
+  .insert-waypoint-btn:hover {
+    background: #d97706;
+  }
+
+  .insert-waypoint-close {
+    background: transparent;
+    color: #fde68a;
+    border: none;
+    padding: 2px 6px;
+    cursor: pointer;
+    font-size: 12px;
+  }
+
+  .insert-waypoint-close:hover {
+    color: white;
   }
 
   /* Next/final waypoint overlay. Sits above the bottom-left stop-panning area

--- a/src/marineMap.svelte
+++ b/src/marineMap.svelte
@@ -1127,7 +1127,28 @@
     }
   }
 
+  // Two-step confirmation for the clear-all-waypoints button. First click
+  // arms the confirm state; second click within CLEAR_CONFIRM_MS commits.
+  // Auto-disarms after the timeout so a forgotten click doesn't lurk.
+  const CLEAR_CONFIRM_MS = 4000;
+  let clearConfirmArmed = $state(false);
+  let clearConfirmTimer: number | undefined;
+
   function clearWaypoints() {
+    if (!clearConfirmArmed) {
+      clearConfirmArmed = true;
+      if (clearConfirmTimer !== undefined) clearTimeout(clearConfirmTimer);
+      clearConfirmTimer = setTimeout(() => {
+        clearConfirmArmed = false;
+        clearConfirmTimer = undefined;
+      }, CLEAR_CONFIRM_MS) as unknown as number;
+      return;
+    }
+    if (clearConfirmTimer !== undefined) {
+      clearTimeout(clearConfirmTimer);
+      clearConfirmTimer = undefined;
+    }
+    clearConfirmArmed = false;
     addWaypointActive = false;
     onClearWaypoints?.();
   }
@@ -2205,6 +2226,11 @@
         container.removeEventListener("click", handleMapContainerClick as EventListener);
       }
 
+      if (clearConfirmTimer !== undefined) {
+        clearTimeout(clearConfirmTimer);
+        clearConfirmTimer = undefined;
+      }
+
       // Remove OpenLayers map event listeners to prevent memory leaks
       if (mapGlobal.map) {
         if (mapClickHandler) {
@@ -2507,11 +2533,14 @@
     {#if navWaypoints && navWaypoints.length > 0}
       <button
         class="clear-waypoints-btn"
+        class:armed={clearConfirmArmed}
         onclick={clearWaypoints}
-        title="Clear all route waypoints"
-        aria-label="Clear route"
+        title={clearConfirmArmed
+          ? "Click again to confirm clearing all waypoints"
+          : "Clear all route waypoints"}
+        aria-label={clearConfirmArmed ? "Confirm clear route" : "Clear route"}
       >
-        ✕
+        {clearConfirmArmed ? "?" : "✕"}
       </button>
     {/if}
   {/if}
@@ -3037,6 +3066,17 @@
   .clear-waypoints-btn:hover {
     background: #fef3c7;
     border-color: #b45309;
+  }
+
+  /* Armed state: red so the second click clearly looks destructive. */
+  .clear-waypoints-btn.armed {
+    background: #dc2626;
+    color: white;
+    border-color: #991b1b;
+  }
+
+  .clear-waypoints-btn.armed:hover {
+    background: #b91c1c;
   }
 
   /* When the data panel is hidden, the map is full-width and its top-right

--- a/src/marineMap.svelte
+++ b/src/marineMap.svelte
@@ -23,6 +23,7 @@
   import { Circle as CircleStyle, Fill, Icon, Stroke, Style } from "ol/style.js";
   import Overlay from "ol/Overlay.js";
   import { getDistance, offset as sphereOffset } from "ol/sphere.js";
+  import Modify from "ol/interaction/Modify.js";
   import type { Geometry } from "ol/geom";
   import type BaseLayer from "ol/layer/Base";
   import type { TileCoord } from "ol/tilecoord";
@@ -227,6 +228,77 @@
     return lat >= -90 && lat <= 90 && lng >= -180 && lng <= 180 && !(lat === 0 && lng === 0); // Exclude null island
   }
 
+  // Initial bearing from `from` to `to` in degrees [0, 360). Standard
+  // forward-azimuth formula; we don't need accuracy beyond what the user
+  // would steer to.
+  function bearingDeg(from: [number, number], to: [number, number]): number {
+    const toRad = (d: number) => (d * Math.PI) / 180;
+    const φ1 = toRad(from[0]);
+    const φ2 = toRad(to[0]);
+    const Δλ = toRad(to[1] - from[1]);
+    const y = Math.sin(Δλ) * Math.cos(φ2);
+    const x = Math.cos(φ1) * Math.sin(φ2) - Math.sin(φ1) * Math.cos(φ2) * Math.cos(Δλ);
+    return ((Math.atan2(y, x) * 180) / Math.PI + 360) % 360;
+  }
+
+  function formatDurationMin(min: number): string {
+    if (!isFinite(min) || min <= 0) return "—";
+    if (min < 60) return `${Math.round(min)} min`;
+    const h = Math.floor(min / 60);
+    const m = Math.round(min % 60);
+    return m === 0 ? `${h}h` : `${h}h ${m}m`;
+  }
+
+  function formatEta(min: number): string {
+    if (!isFinite(min) || min <= 0) return "—";
+    const eta = new Date(Date.now() + min * 60000);
+    return eta.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+  }
+
+  // Derived overlay stats for the active route. Recomputes whenever the boat
+  // pose or waypoint list changes.
+  let routeStats = $derived.by(() => {
+    if (!navWaypoints || navWaypoints.length === 0 || !myBoat) return null;
+    if (!isValidCoordinate(myBoat.location[0], myBoat.location[1])) return null;
+
+    const speedKn = myBoat.speed ?? 0;
+    const startLngLat: [number, number] = [myBoat.location[1], myBoat.location[0]];
+
+    const next = navWaypoints[0];
+    const nextLngLat: [number, number] = [next.lng, next.lat];
+    const nextMeters = getDistance(startLngLat, nextLngLat);
+    const nextNm = nextMeters / 1852;
+    const nextBearing = bearingDeg(
+      [myBoat.location[0], myBoat.location[1]],
+      [next.lat, next.lng]
+    );
+    // hours = nm / kn ; convert to minutes
+    const nextMin = speedKn > 0.1 ? (nextNm / speedKn) * 60 : Infinity;
+
+    let totalMeters = nextMeters;
+    let prev = nextLngLat;
+    for (let i = 1; i < navWaypoints.length; i++) {
+      const cur: [number, number] = [navWaypoints[i].lng, navWaypoints[i].lat];
+      totalMeters += getDistance(prev, cur);
+      prev = cur;
+    }
+    const totalNm = totalMeters / 1852;
+    const totalMin = speedKn > 0.1 ? (totalNm / speedKn) * 60 : Infinity;
+
+    return {
+      next: {
+        distNm: nextNm,
+        headingDeg: nextBearing,
+        minutes: nextMin,
+      },
+      final: {
+        distNm: totalNm,
+        minutes: totalMin,
+        waypointCount: navWaypoints.length,
+      },
+    };
+  });
+
   function fitToVisibleBoats() {
     if (!mapGlobal.map || !mapGlobal.view) return;
 
@@ -315,6 +387,7 @@
     fullWidth = false,
     navWaypoints,
     onAddWaypoint,
+    onMoveWaypoint,
     onClearWaypoints,
     onReady,
     boatDetailSlot,
@@ -334,6 +407,8 @@
     navWaypoints?: { id: string; lat: number; lng: number }[];
     /** Called when the user clicks the map while "add waypoint" mode is active. */
     onAddWaypoint?: (lat: number, lng: number) => void;
+    /** Called when the user finishes dragging an existing waypoint. */
+    onMoveWaypoint?: (id: string, lat: number, lng: number) => void;
     /** Called when the user clicks the clear-route button. */
     onClearWaypoints?: () => void;
     /** When true, parent controls visibility via setVisibleBoats API instead of auto-showing new boats */
@@ -449,7 +524,8 @@
     trackFeatures: new Collection<Feature<Geometry>>(),
     aisTrackFeatures: new Collection<Feature<Geometry>>(),
     routeFeatures: new Collection<Feature<Geometry>>(),
-    navRouteFeatures: new Collection<Feature<Geometry>>(),
+    navRouteLineFeatures: new Collection<Feature<Geometry>>(),
+    navWaypointFeatures: new Collection<Feature<Geometry>>(),
     headingLineFeatures: new Collection<Feature<Geometry>>(),
     trackFeaturesLastCheck: new Date(0),
     myBoatMarker: null as Feature<Point> | null,
@@ -559,8 +635,11 @@
     }
 
     // navigation-service route: draws a polyline from the boat through each
-    // waypoint in order, plus a circle marker at every waypoint.
-    mapGlobal.navRouteFeatures.clear();
+    // waypoint in order, plus a circle marker at every waypoint. The line and
+    // markers live in separate sources so the Modify interaction can target
+    // only the markers (LineStrings would otherwise grow new control points
+    // on drag).
+    mapGlobal.navRouteLineFeatures.clear();
     if (navWaypoints && navWaypoints.length > 0) {
       const wpCoords: number[][] = navWaypoints.map((wp) => [wp.lng, wp.lat]);
 
@@ -571,21 +650,12 @@
       const lineCoords = startCoord ? [startCoord, ...wpCoords] : wpCoords;
 
       if (lineCoords.length >= 2) {
-        mapGlobal.navRouteFeatures.push(
+        mapGlobal.navRouteLineFeatures.push(
           new Feature({ type: "navRoute", geometry: new LineString(lineCoords) })
         );
       }
-      navWaypoints.forEach((wp, idx) => {
-        mapGlobal.navRouteFeatures.push(
-          new Feature({
-            type: "navWaypoint",
-            waypointId: wp.id,
-            waypointIndex: idx,
-            geometry: new Point([wp.lng, wp.lat]),
-          })
-        );
-      });
     }
+    syncNavWaypointFeatures();
 
     if (boats == null) {
       mapGlobal.aisFeatures.clear();
@@ -1026,6 +1096,96 @@
     onClearWaypoints?.();
   }
 
+  // Reconcile the waypoint marker collection against the latest navWaypoints
+  // prop. We mutate-in-place rather than clearing/repopulating because the
+  // Modify interaction holds direct references to the Feature objects: blowing
+  // them away mid-drag would drop the user's gesture. While a marker is being
+  // dragged we leave it untouched so the drag can finish cleanly.
+  function syncNavWaypointFeatures() {
+    const desired = navWaypoints ?? [];
+    const desiredById = new Map(desired.map((wp) => [wp.id, wp]));
+
+    const features = mapGlobal.navWaypointFeatures;
+    for (let i = features.getLength() - 1; i >= 0; i--) {
+      const feat = features.item(i) as Feature<Point>;
+      const id = feat.get("waypointId") as string;
+      if (!desiredById.has(id) && id !== draggingWaypointId) {
+        features.removeAt(i);
+      }
+    }
+
+    const existingById = new Map<string, Feature<Point>>();
+    features.forEach((f) => existingById.set(f.get("waypointId") as string, f as Feature<Point>));
+
+    desired.forEach((wp, idx) => {
+      const existing = existingById.get(wp.id);
+      if (existing) {
+        if (wp.id !== draggingWaypointId) {
+          existing.setGeometry(new Point([wp.lng, wp.lat]));
+        }
+        existing.set("waypointIndex", idx);
+        return;
+      }
+      features.push(
+        new Feature({
+          type: "navWaypoint",
+          waypointId: wp.id,
+          waypointIndex: idx,
+          geometry: new Point([wp.lng, wp.lat]),
+        })
+      );
+    });
+  }
+
+  let draggingWaypointId: string | null = null;
+  let waypointModifyInteraction: Modify | null = null;
+  let waypointModifySource: VectorSource | null = null;
+
+  // The Modify interaction is added/removed alongside the "add waypoint" mode
+  // toggle so dragging is only possible while the user has explicitly opted in
+  // (this also avoids accidental drags during normal panning).
+  $effect(() => {
+    if (!mapGlobal.map) return;
+    if (addWaypointActive && onMoveWaypoint && !waypointModifyInteraction) {
+      installWaypointModify();
+    } else if ((!addWaypointActive || !onMoveWaypoint) && waypointModifyInteraction) {
+      uninstallWaypointModify();
+    }
+  });
+
+  function installWaypointModify() {
+    if (!mapGlobal.map || !waypointModifySource) return;
+    waypointModifyInteraction = new Modify({
+      source: waypointModifySource,
+      // Restrict drags to the marker points: a route's line segments live in
+      // a different layer/source so they can't be edited.
+      pixelTolerance: 12,
+    });
+    waypointModifyInteraction.on("modifystart", (evt) => {
+      const feat = evt.features.item(0) as Feature<Point> | undefined;
+      draggingWaypointId = (feat?.get("waypointId") as string) ?? null;
+    });
+    waypointModifyInteraction.on("modifyend", (evt) => {
+      const feat = evt.features.item(0) as Feature<Point> | undefined;
+      draggingWaypointId = null;
+      if (!feat || !onMoveWaypoint) return;
+      const id = feat.get("waypointId") as string;
+      const geom = feat.getGeometry();
+      if (!id || !geom) return;
+      const [lng, lat] = geom.getCoordinates();
+      onMoveWaypoint(id, lat, lng);
+    });
+    mapGlobal.map.addInteraction(waypointModifyInteraction);
+  }
+
+  function uninstallWaypointModify() {
+    if (mapGlobal.map && waypointModifyInteraction) {
+      mapGlobal.map.removeInteraction(waypointModifyInteraction);
+    }
+    waypointModifyInteraction = null;
+    draggingWaypointId = null;
+  }
+
   function toggleHeadsUp() {
     headsUpActive = !headsUpActive;
     setCookie(COOKIE_HEADS_UP, headsUpActive ? "1" : "0", COOKIE_OPTS);
@@ -1365,36 +1525,49 @@
       });
 
       // Nav-service route: line + waypoint markers driven by `navWaypoints`.
-      var navRouteLayer = new Vector({
+      // Two layers/sources (line and markers) so drag-to-edit only affects the
+      // markers.
+      var navRouteLineLayer = new Vector({
         source: new VectorSource({
-          features: mapGlobal.navRouteFeatures,
+          features: mapGlobal.navRouteLineFeatures,
         }),
-        style: function (feature) {
-          if (feature.get("type") === "navWaypoint") {
-            return new Style({
-              image: new CircleStyle({
-                radius: 7,
-                fill: new Fill({ color: "#f59e0b" }),
-                stroke: new Stroke({ color: "white", width: 2 }),
-              }),
-            });
-          }
-          return new Style({
-            stroke: new Stroke({
-              color: "#f59e0b",
-              width: 3,
-              lineDash: [10, 6],
-            }),
-          });
-        },
+        style: new Style({
+          stroke: new Stroke({
+            color: "#f59e0b",
+            width: 3,
+            lineDash: [10, 6],
+          }),
+        }),
         zIndex: 21,
+      });
+
+      waypointModifySource = new VectorSource({
+        features: mapGlobal.navWaypointFeatures,
+      });
+      var navWaypointLayer = new Vector({
+        source: waypointModifySource,
+        style: new Style({
+          image: new CircleStyle({
+            radius: 7,
+            fill: new Fill({ color: "#f59e0b" }),
+            stroke: new Stroke({ color: "white", width: 2 }),
+          }),
+        }),
+        zIndex: 22,
       });
 
       mapGlobal.layerOptions.push({
         name: "nav-route",
         displayName: "nav route",
         on: true,
-        layer: navRouteLayer,
+        layer: navRouteLineLayer,
+        parent: "boat",
+      });
+      mapGlobal.layerOptions.push({
+        name: "nav-waypoints",
+        displayName: "waypoints",
+        on: true,
+        layer: navWaypointLayer,
         parent: "boat",
       });
     }
@@ -2220,6 +2393,30 @@
       {measureDistance.toFixed(2)} nm ({(measureDistance * 1.15078).toFixed(2)} mi)
     </div>
   {/if}
+
+  {#if routeStats}
+    <div class="route-stats" class:edit={addWaypointActive}>
+      <div class="route-stats-row">
+        <span class="route-stats-label">Next</span>
+        <span class="route-stats-value">{routeStats.next.distNm.toFixed(2)} nm</span>
+        <span class="route-stats-value">{routeStats.next.headingDeg.toFixed(0)}°</span>
+        <span class="route-stats-value">{formatDurationMin(routeStats.next.minutes)}</span>
+        <span class="route-stats-value">ETA {formatEta(routeStats.next.minutes)}</span>
+      </div>
+      {#if routeStats.final.waypointCount > 1}
+        <div class="route-stats-row">
+          <span class="route-stats-label">Final</span>
+          <span class="route-stats-value">{routeStats.final.distNm.toFixed(2)} nm</span>
+          <span class="route-stats-value route-stats-spacer"></span>
+          <span class="route-stats-value">{formatDurationMin(routeStats.final.minutes)}</span>
+          <span class="route-stats-value">ETA {formatEta(routeStats.final.minutes)}</span>
+        </div>
+      {/if}
+      {#if addWaypointActive}
+        <div class="route-stats-hint">click to add · drag waypoints to move</div>
+      {/if}
+    </div>
+  {/if}
 </div>
 
 <style>
@@ -2695,6 +2892,61 @@
     box-shadow: 0 1px 4px rgba(0, 0, 0, 0.3);
     z-index: 1000;
     white-space: nowrap;
+  }
+
+  /* Next/final waypoint overlay. Sits above the bottom-left stop-panning area
+     so it stays visible whether the data panel is open or not. */
+  .route-stats {
+    position: absolute;
+    bottom: 10px;
+    left: 10px;
+    padding: 6px 10px;
+    background: rgba(15, 23, 42, 0.92);
+    color: #fde68a;
+    border: 1px solid rgba(245, 158, 11, 0.6);
+    border-radius: 4px;
+    font-size: 12px;
+    font-family:
+      system-ui,
+      -apple-system,
+      sans-serif;
+    box-shadow: 0 1px 4px rgba(0, 0, 0, 0.3);
+    z-index: 1001;
+    pointer-events: none;
+    line-height: 1.35;
+  }
+
+  .route-stats.edit {
+    border-color: #f59e0b;
+    background: rgba(120, 53, 15, 0.92);
+  }
+
+  .route-stats-row {
+    display: flex;
+    gap: 10px;
+    align-items: baseline;
+    white-space: nowrap;
+  }
+
+  .route-stats-label {
+    font-weight: 600;
+    color: #f59e0b;
+    min-width: 38px;
+  }
+
+  .route-stats-value {
+    font-variant-numeric: tabular-nums;
+  }
+
+  .route-stats-spacer {
+    visibility: hidden;
+  }
+
+  .route-stats-hint {
+    margin-top: 4px;
+    color: #fef3c7;
+    font-size: 11px;
+    opacity: 0.8;
   }
 
   /* Boats panel (bottom-right, next to Layers) */


### PR DESCRIPTION
## Summary
This PR adds waypoint management capabilities to the chartplotter, allowing users to add and manage navigation waypoints through the map interface. It includes a new navigation service implementation and UI controls for waypoint manipulation.

## Key Changes

### Frontend (Svelte)
- Added "Add Waypoint" toggle button to the map toolbar that enables click-to-add mode for waypoints
- Added "Clear Route" button that appears when waypoints exist
- Implemented visual rendering of navigation routes as dashed amber lines with circular waypoint markers
- Added "+ Route From Here" button to quickly add a waypoint at the current boat position
- Integrated waypoint polling from the navigation service and state management in the app

### Backend (Go)
- **New Navigation Service** (`nav.go`): Implements the Viam navigation service API with support for:
  - Mode management (Manual, Waypoint, Explore)
  - Location tracking via optional movement sensor
  - Waypoint CRUD operations
  
- **Persistent Waypoint Store** (`nav_store.go`): Disk-backed navigation store that:
  - Persists waypoints to JSON files across module restarts
  - Handles atomic file writes (tmp+rename pattern) to prevent corruption
  - Filters out visited waypoints from the active list
  - Manages waypoint lifecycle (add, remove, mark visited)

### Configuration
- Updated module metadata to register the new navigation service
- Added navigation service initialization in module command

## Implementation Details

- Waypoints are displayed as amber-colored circular markers (radius 7px) with white borders
- Navigation routes are rendered as dashed amber lines (10px dash, 6px gap) connecting the boat position through each waypoint in order
- The "Add Waypoint" mode is mutually exclusive with measurement mode
- Waypoint IDs use MongoDB ObjectID format for consistency with Viam's navigation API
- Cursor changes to crosshair when in waypoint-add or measurement mode
- Waypoint persistence uses a human-friendly JSON schema with string IDs and named coordinate fields

https://claude.ai/code/session_016Wwb2KqJ2UvXyVT6onWUEB