### PR TITLE
Add NOAA WMS caching proxy support with fallback

### DIFF
--- a/src/marineMap.svelte
+++ b/src/marineMap.svelte
@@ -1499,9 +1499,12 @@
     });
 
     // NOAA's public WMS chart service. Authoritative but slow — kept as a
-    // fallback / comparison reference. Always available regardless of where the
-    // page is being served from. The `_v` param is ignored by the WMS but
-    // changes the browser cache key when tileGenVersion is bumped.
+    // fallback / comparison reference. When served from the Go module (or
+    // proxied by Vite), we route through `/noaa-wms/proxy` so the disk cache
+    // absorbs repeat tile fetches; otherwise we hit NOAA directly.
+    const noaaWmsUrl = noaaCacheReachable()
+      ? "/noaa-wms/proxy"
+      : "https://gis.charttools.noaa.gov/arcgis/rest/services/MCS/NOAAChartDisplay/MapServer/exts/MaritimeChartService/WMSServer";
     mapGlobal.layerOptions.push({
       name: "noaa",
       on: false,
@@ -1510,7 +1513,7 @@
         preload: 2,
         zIndex: 4,
         source: new TileWMS({
-          url: "https://gis.charttools.noaa.gov/arcgis/rest/services/MCS/NOAAChartDisplay/MapServer/exts/MaritimeChartService/WMSServer",
+          url: noaaWmsUrl,
           params: { _v: tileGenVersion },
           transition: 300,
         }),

--- a/src/marineMap.svelte
+++ b/src/marineMap.svelte
@@ -1514,7 +1514,7 @@
         zIndex: 4,
         source: new TileWMS({
           url: noaaWmsUrl,
-          params: { _v: tileGenVersion },
+          params: { LAYERS: "0,1,2,3,4,5,6", _v: tileGenVersion },
           transition: 300,
         }),
       }),


### PR DESCRIPTION
## Summary
Updated the NOAA WMS chart service integration to intelligently route tile requests through a local caching proxy when available, with automatic fallback to direct NOAA service access.

## Key Changes
- Added conditional logic to detect if the NOAA WMS caching proxy is reachable via `noaaCacheReachable()`
- When the proxy is available, routes requests through `/noaa-wms/proxy` to leverage disk caching for repeated tile fetches
- Falls back to direct NOAA service URL (`https://gis.charttools.noaa.gov/...`) when proxy is unavailable
- Updated comments to clarify the new caching strategy and deployment scenarios (Go module or Vite proxy)

## Implementation Details
- The proxy URL is determined at runtime based on deployment context
- This optimization reduces redundant tile fetches when served from the Go module or proxied by Vite
- Direct NOAA access remains available as a reliable fallback for all deployment scenarios

https://claude.ai/code/session_011Ws4S7fQ7BDAYzmhiRpWU5