### PR TITLE
Increase z-index of marine map component to 1003

### DIFF
--- a/src/marineMap.svelte
+++ b/src/marineMap.svelte
@@ -4464,7 +4464,7 @@
       system-ui,
       -apple-system,
       sans-serif;
-    z-index: 1000;
+    z-index: 1003;
     color: #333;
     box-shadow: 0 1px 4px rgba(0, 0, 0, 0.2);
     border: 1px solid #ccc;


### PR DESCRIPTION
## Summary
Updated the z-index stacking order of the marine map component to prevent layering issues with other UI elements.

## Changes
- Increased z-index from 1000 to 1003 in the marineMap.svelte component styles

## Details
This change adjusts the stacking context of the marine map component to ensure it displays above other elements with z-index values between 1000 and 1002. This is a minor z-index adjustment to resolve potential visual layering conflicts with overlapping UI components.

https://claude.ai/code/session_01RM4YNtrLfM1XsqsmWbwhGJ