### PR TITLE
Remove unused tile URL function and map layers

### DIFF
--- a/src/marineMap.svelte
+++ b/src/marineMap.svelte
@@ -27,7 +27,6 @@
   import MouseWheelZoom from "ol/interaction/MouseWheelZoom.js";
   import type { Geometry } from "ol/geom";
   import type BaseLayer from "ol/layer/Base";
-  import type { TileCoord } from "ol/tilecoord";
 
   interface LayerOption {
     name: string;
@@ -1465,25 +1464,6 @@
     });
   }
 
-  function getTileUrlFunction(
-    url: string,
-    type: string,
-    coordinates: TileCoord
-  ): string | undefined {
-    var x = coordinates[1];
-    var y = coordinates[2];
-    var z = coordinates[0];
-    var limit = Math.pow(2, z);
-    if (y < 0 || y >= limit) {
-      return undefined;
-    } else {
-      x = ((x % limit) + limit) % limit;
-
-      var path = z + "/" + x + "/" + y + "." + type;
-      return url + path;
-    }
-  }
-
   function toggleMeasure() {
     if (measureActive) {
       stopMeasure();
@@ -1894,48 +1874,6 @@
           url: "https://tile.openstreetmap.org/{z}/{x}/{y}.png",
           transition: 250, // Faster fade-in
         }),
-      }),
-    });
-
-    // depth data
-    mapGlobal.layerOptions.push({
-      name: "depth",
-      on: false,
-      layer: new TileLayer({
-        opacity: 0.7,
-        preload: 2,
-        zIndex: 2,
-        source: new TileWMS({
-          url: "https://geoserver.openseamap.org/geoserver/gwc/service/wms",
-          params: { LAYERS: "gebco2021:gebco_2021", VERSION: "1.1.1" },
-          serverType: "geoserver",
-          hidpi: false,
-          transition: 300,
-        }),
-      }),
-    });
-
-    // harbors
-    mapGlobal.layerOptions.push({
-      name: "seamark",
-      on: false,
-      layer: new TileLayer({
-        visible: true,
-        maxZoom: 19,
-        preload: 2,
-        zIndex: 3,
-        source: new XYZ({
-          tileUrlFunction: function (coordinate) {
-            return getTileUrlFunction("https://tiles.openseamap.org/seamark/", "png", coordinate);
-          },
-          transition: 300,
-        }),
-        properties: {
-          name: "seamarks",
-          layerId: 3,
-          cookieKey: "SeamarkLayerVisible",
-          checkboxId: "checkLayerSeamark",
-        },
       }),
     });
 


### PR DESCRIPTION
## Summary
This PR removes unused code from the marine map component, specifically an unused tile URL utility function and two map layer configurations that are no longer needed.

## Key Changes
- Removed `getTileUrlFunction()` helper function that was used to construct tile URLs with coordinate wrapping logic
- Removed the unused `TileCoord` type import from OpenLayers
- Removed the "depth" map layer (GEBCO 2021 bathymetry data from GeoServer)
- Removed the "seamark" map layer (OpenSeaMap seamark tiles)

## Details
The removed code appears to be legacy functionality that is no longer actively used in the application. The `getTileUrlFunction()` was only referenced by the seamark layer configuration, so removing both eliminates dead code. The depth layer configuration was also disabled by default (`on: false`) and has been removed as part of this cleanup.

https://claude.ai/code/session_01MeydxoMSXb1pJcThvtHPKs