### PR TITLE
Suppress OSM base layer when NOAA local chart is active

### DIFF
--- a/src/marineMap.svelte
+++ b/src/marineMap.svelte
@@ -2743,6 +2743,15 @@
     const myBoatPopupForceTrack =
       popupState.visible && popupState.content.isMyBoat;
 
+    // noaa-local already paints OSM detail under its chart (osm-detail child
+     // layer) — the global OSM base layer underneath is redundant and bleeds
+     // through where noaa-local has transparent water/land. Suppress it
+     // whenever noaa-local is on.
+    const noaaLocalLayer = mapGlobal.layerOptions.find(
+      (p) => p.name === "noaa-local",
+    );
+    const noaaLocalOn = !!noaaLocalLayer && noaaLocalLayer.on;
+
     for (var l of mapGlobal.layerOptions) {
       var idx = findOnLayerIndexOfName(l.name);
 
@@ -2754,8 +2763,12 @@
         (l.name === "ais-track" && aisPopupForceTrack) ||
         (l.name === "track" && myBoatPopupForceTrack);
 
+      const suppressedByNoaaLocal =
+        l.name === "open street map" && noaaLocalOn;
+
       // Layer should be visible only if it's on AND (has no parent OR parent is on)
-      const shouldBeVisible = (l.on || popupForcesOn) && !isParentOff;
+      const shouldBeVisible =
+        (l.on || popupForcesOn) && !isParentOff && !suppressedByNoaaLocal;
 
       if (shouldBeVisible) {
         if (idx < 0) {
@@ -4041,12 +4054,17 @@
   {/if}
 
   <div class="layer-controls">
+    {@const noaaLocalActive = !!mapGlobal.layerOptions.find(
+      (p) => p.name === "noaa-local" && p.on,
+    )}
     {#each mapGlobal.layerOptions as l, idx}
       {@const parentLayer = l.parent
         ? mapGlobal.layerOptions.find((p) => p.name === l.parent)
         : null}
       {@const isParentOff = parentLayer && !parentLayer.on}
-      {@const isHidden = l.name === "airstream" && !airstreamConfigured}
+      {@const isHidden =
+        (l.name === "airstream" && !airstreamConfigured) ||
+        (l.name === "open street map" && noaaLocalActive)}
       {#if !isHidden}
       <label class:child-layer={l.parent} class:disabled={isParentOff}>
         <input


### PR DESCRIPTION
## Summary
This change prevents the global OpenStreetMap base layer from displaying when the NOAA local chart layer is active, eliminating visual artifacts where the OSM layer bleeds through transparent areas of the NOAA chart.

## Key Changes
- Added logic to detect when the "noaa-local" layer is enabled
- Suppress the "open street map" base layer visibility whenever "noaa-local" is active, since NOAA local already includes its own OSM detail as a child layer
- Updated both the layer visibility calculation logic and the layer controls UI to respect this suppression rule

## Implementation Details
- The suppression check is performed in two places:
  1. In the main layer visibility logic (around line 2760) where layer visibility is determined for rendering
  2. In the layer controls UI (around line 4060) where layer toggles are displayed to the user
- The "open street map" layer remains functional and can be toggled when NOAA local is off, but is automatically hidden when NOAA local is enabled
- This prevents redundant rendering and visual confusion from overlapping map layers

https://claude.ai/code/session_01TESpT7H3rLq6MNi5Z6xXBe