### PR TITLE
Add free satellite imagery base layer using Esri World Imagery

### DIFF
--- a/src/marineMap.svelte
+++ b/src/marineMap.svelte
@@ -187,7 +187,7 @@
   // The layer panel renders these (and their children) above a divider as
   // radio buttons; everything else (boat, ais, airstream + their children)
   // renders below as independent checkboxes.
-  const BASE_LAYER_NAMES = ["open street map", "noaa", "checkmate", "noaa-ecdis"];
+  const BASE_LAYER_NAMES = ["open street map", "satellite", "noaa", "checkmate", "noaa-ecdis"];
   function isBaseLayerGroup(l: { name: string; parent?: string }): boolean {
     return (
       BASE_LAYER_NAMES.includes(l.name) ||
@@ -2685,6 +2685,31 @@
             return `https://tile.openstreetmap.org/${z}/${x}/${y}.png`;
           },
           transition: 250, // Faster fade-in
+        }),
+      }),
+    });
+
+    // Free satellite imagery base — Esri World Imagery. No API key, CORS-enabled,
+    // and free to use with attribution. Global high-res aerial/satellite coverage,
+    // which is handy in waters NOAA never charted and as a real-world reference
+    // alongside the chart. A mutually-exclusive base (radio), default off. Note
+    // Esri's tile path is {z}/{y}/{x} (row before column), not the usual
+    // {z}/{x}/{y}.
+    mapGlobal.layerOptions.push({
+      name: "satellite",
+      displayName: "satellite",
+      on: false,
+      layer: new TileLayer({
+        opacity: 1,
+        preload: Infinity,
+        zIndex: 2,
+        source: new XYZ({
+          url: "https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}",
+          crossOrigin: "anonymous",
+          maxZoom: 19,
+          attributions:
+            "Source: Esri, Maxar, Earthstar Geographics, and the GIS User Community",
+          transition: 250,
         }),
       }),
     });


### PR DESCRIPTION
## Summary
Added a new satellite imagery base layer to the marine map using Esri's World Imagery service, providing global high-resolution aerial/satellite coverage as an alternative to existing chart layers.

## Key Changes
- Added "satellite" to the `BASE_LAYER_NAMES` array to register it as a mutually-exclusive base layer (radio button in the layer panel)
- Implemented new satellite layer using Esri's World Imagery tile service with the following characteristics:
  - Free to use with proper attribution
  - No API key required
  - CORS-enabled for cross-origin requests
  - Global coverage with high-resolution aerial/satellite imagery
  - Disabled by default (`on: false`)
  - Maximum zoom level of 19

## Implementation Details
- Uses OpenLayers `TileLayer` with `XYZ` source pointing to Esri's ArcGIS tile service
- Properly handles Esri's non-standard tile coordinate order (`{z}/{y}/{x}` instead of `{z}/{x}/{y}`)
- Configured with appropriate opacity, preload settings, and z-index to work as a base layer
- Includes proper attribution text crediting Esri, Maxar, Earthstar Geographics, and the GIS User Community
- Smooth 250ms transition effect when switching between layers

https://claude.ai/code/session_01Lt3cb4bRnjWNy987CvLu5N