### PR TITLE
Add free satellite (aerial) base map option

### DIFF
--- a/src/marineMap.svelte
+++ b/src/marineMap.svelte
@@ -187,7 +187,7 @@
   // The layer panel renders these (and their children) above a divider as
   // radio buttons; everything else (boat, ais, airstream + their children)
   // renders below as independent checkboxes.
-  const BASE_LAYER_NAMES = ["open street map", "satellite", "noaa", "checkmate", "noaa-ecdis"];
+  const BASE_LAYER_NAMES = ["open street map", "satellite-imagery", "noaa", "checkmate", "noaa-ecdis"];
   function isBaseLayerGroup(l: { name: string; parent?: string }): boolean {
     return (
       BASE_LAYER_NAMES.includes(l.name) ||
@@ -2690,14 +2690,16 @@
     });
 
     // Free satellite imagery base — Esri World Imagery. No API key, CORS-enabled,
-    // and free to use with attribution. Global high-res aerial/satellite coverage,
-    // which is handy in waters NOAA never charted and as a real-world reference
-    // alongside the chart. A mutually-exclusive base (radio), default off. Note
-    // Esri's tile path is {z}/{y}/{x} (row before column), not the usual
+    // and free to use with attribution. Global high-res aerial/satellite coverage
+    // (Google-Maps-satellite style), handy in waters NOAA never charted and as a
+    // real-world reference alongside the chart. A mutually-exclusive base (radio),
+    // default off. Distinct from the weather "satellite" overlay (GOES cloud
+    // imagery), so it carries its own name to avoid colliding with that layer.
+    // Note Esri's tile path is {z}/{y}/{x} (row before column), not the usual
     // {z}/{x}/{y}.
     mapGlobal.layerOptions.push({
-      name: "satellite",
-      displayName: "satellite",
+      name: "satellite-imagery",
+      displayName: "satellite (aerial)",
       on: false,
       layer: new TileLayer({
         opacity: 1,


### PR DESCRIPTION
## What

Adds a free **satellite (aerial)** base map — Esri World Imagery — as a mutually-exclusive base layer (radio toggle), alongside OpenStreetMap / NOAA / Checkmate. This is Google-Maps-satellite-style aerial imagery, distinct from the existing GOES weather-cloud "satellite" overlay.

## Why

- Free, no API key required, CORS-enabled
- Global high-res aerial coverage — useful in waters NOAA never charted, and as a real-world reference alongside the chart

## Details

- Registered in `setupLayers()` as an OpenLayers `XYZ` source. Esri's tile path is `{z}/{y}/{x}` (row before column), handled accordingly.
- Carries the required Esri/Maxar/Earthstar attribution and sits at `zIndex: 2` (above the OSM base, below the charts).
- Uses a unique layer name `satellite-imagery` (displayName "satellite (aerial)") to avoid colliding with the existing weather `satellite` overlay (GOES cloud imagery) in `WeatherOverlays.svelte`, which guards its own registration by name.
- Default off; left out of `CHART_BASE_NAMES` so it behaves as its own opaque base.

## Testing

- `npm run build` passes.
- ESLint on the changed file shows only pre-existing errors unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lt3cb4bRnjWNy987CvLu5N)_