### PR TITLE
Add NMEA 2000 waypoint export and GPX download support

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ UI's waypoints/route persistently and reports progress to the next waypoint.
 |-----------|------|---------|-------------|
 | `movement_sensor` | string | — | name of a movement sensor for position (becomes a dependency) |
 | `data_path` | string | — | file path to persist waypoints across restarts |
+| `n2k_sender` | string | — | name of a generic component whose DoCommand sends raw NMEA 2000 PGNs (e.g. a `viam-labs:viamboat:sender`; becomes a dependency). Enables `send_waypoints_n2k`. |
 
 ```json
 {
@@ -69,9 +70,18 @@ UI's waypoints/route persistently and reports progress to the next waypoint.
   "namespace": "rdk",
   "type": "navigation",
   "model": "erh:viam-chartplotter:nav",
-  "attributes": { "movement_sensor": "gps", "data_path": "/data/nav.json" }
+  "attributes": { "movement_sensor": "gps", "data_path": "/data/nav.json", "n2k_sender": "n2k-sender" }
 }
 ```
+
+With `n2k_sender` configured, the DoCommand
+`{"send_waypoints_n2k": {"route_name"?: string, "database_id"?: int, "route_id"?: int, "dst"?: int}}`
+pushes the current waypoint list onto the NMEA 2000 bus as a Route and WP
+Service transfer — one PGN 130066 (Route/WP-List Attributes) followed by PGN
+130067 (Route – WP Name & Position) messages, chunked to fit fast-packets — so
+a chartplotter (e.g. Garmin) on the same backbone can pick the route up. All
+payload fields are optional; pass `true` for the defaults (route name
+"Chartplotter", broadcast).
 
 ---
 

--- a/nav.go
+++ b/nav.go
@@ -13,6 +13,7 @@ import (
 	"go.mongodb.org/mongo-driver/bson/primitive"
 
 	"go.viam.com/rdk/app"
+	"go.viam.com/rdk/components/generic"
 	"go.viam.com/rdk/components/movementsensor"
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/resource"
@@ -38,9 +39,14 @@ func init() {
 // DataPath, when set, is used as the JSON file that mirrors the waypoint
 // list across restarts. When empty, waypoints persist to
 // "<user-cache-dir>/viam-chartplotter/nav/<resource_name>.json".
+//
+// N2KSender is optional; when set it names a generic component (e.g. a
+// viam-labs:viamboat:sender) whose DoCommand sends raw NMEA 2000 PGNs, and it
+// enables the send_waypoints_n2k DoCommand (see nav_n2k.go).
 type NavConfig struct {
 	MovementSensor string `json:"movement_sensor,omitempty"`
 	DataPath       string `json:"data_path,omitempty"`
+	N2KSender      string `json:"n2k_sender,omitempty"`
 }
 
 // Validate ensures all parts of the config are valid and returns the
@@ -49,6 +55,9 @@ func (cfg *NavConfig) Validate(path string) ([]string, []string, error) {
 	var deps []string
 	if cfg.MovementSensor != "" {
 		deps = append(deps, cfg.MovementSensor)
+	}
+	if cfg.N2KSender != "" {
+		deps = append(deps, cfg.N2KSender)
 	}
 	return deps, nil, nil
 }
@@ -144,6 +153,15 @@ func newNav(
 			arrivalDistanceMeters, nearWaypointMeters, arrivalCheckInterval)
 	}
 
+	if cfg.N2KSender != "" {
+		sender, err := generic.FromDependencies(deps, cfg.N2KSender)
+		if err != nil {
+			return nil, errors.Wrapf(err, "could not get n2k_sender %q", cfg.N2KSender)
+		}
+		svc.n2kSender = sender
+		logger.Infof("nav n2k waypoint export enabled via sender %q", cfg.N2KSender)
+	}
+
 	return svc, nil
 }
 
@@ -156,6 +174,10 @@ type navService struct {
 	mu    sync.Mutex
 	store navigation.NavStore
 	ms    movementsensor.MovementSensor
+
+	// Optional generic component that sends raw NMEA 2000 PGNs via its
+	// DoCommand (config `n2k_sender`); nil disables send_waypoints_n2k.
+	n2kSender resource.Resource
 
 	// mode is held atomically so reads don't need to take the mutex.
 	mode atomic.Uint32
@@ -421,10 +443,16 @@ func (s *navService) Properties(ctx context.Context) (navigation.Properties, err
 //	{"routes_delete":   {"id": "<id>"}}
 //	{"routes_rename":   {"id": "<id>", "name"?: ..., "notes"?: ..., "color"?: ..., "updatedAt"?: ...}}
 //	{"arrival_status":  true}
+//	{"send_waypoints_n2k": {"route_name"?: ..., "database_id"?: ..., "route_id"?: ..., "dst"?: ...}}
 //
 // The routes_* verbs read/write saved routes in the location metadata via the
 // Viam app API (see nav_routes.go), so the browser doesn't need its own cloud
 // credentials.
+//
+// send_waypoints_n2k pushes the current waypoint list onto the NMEA 2000 bus
+// as a Route and WP Service transfer (PGNs 130066 + 130067) via the
+// configured n2k_sender component (see nav_n2k.go). All payload fields are
+// optional; pass true for the defaults.
 //
 // move_waypoint updates an existing waypoint in place (preserving its ID and
 // order). insert_waypoint inserts a new waypoint immediately before the
@@ -458,6 +486,9 @@ func (s *navService) DoCommand(ctx context.Context, cmd map[string]interface{}) 
 	}
 	if _, ok := cmd["arrival_status"]; ok {
 		return s.doArrivalStatus(ctx)
+	}
+	if raw, ok := cmd["send_waypoints_n2k"]; ok {
+		return s.doSendWaypointsN2K(ctx, raw)
 	}
 	return nil, resource.ErrDoUnimplemented
 }

--- a/nav_n2k.go
+++ b/nav_n2k.go
@@ -1,0 +1,216 @@
+package vc
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/pkg/errors"
+
+	"go.viam.com/rdk/services/navigation"
+)
+
+// NMEA 2000 "Route and WP Service" transfer of the active waypoint list.
+//
+// The nav service doesn't own a CAN interface; it delegates to a configured
+// generic sender component (`n2k_sender`, e.g. viam-labs:viamboat:sender)
+// whose DoCommand accepts {"pgn", "priority", "dst", "fields"} and marshals
+// the fields with canboat field names. A transfer is one PGN 130066
+// (Route/WP-List Attributes) announcing the route, followed by PGN 130067
+// (Route - WP Name & Position) messages carrying the waypoints, chunked so
+// each message fits in a single NMEA 2000 fast-packet.
+
+const (
+	pgnRouteWPListAttributes = 130066
+	pgnRouteWPNamePosition   = 130067
+
+	// routeWPPriority: route transfer is not time-critical, so use the
+	// lowest CAN priority.
+	routeWPPriority = 7
+
+	// fastPacketMaxBytes is the max marshaled size of one fast-packet PGN
+	// (6 bytes in frame 0 + 7 bytes in each of 31 continuation frames).
+	fastPacketMaxBytes = 223
+	// wpListHeaderBytes: Start RPS# (1) + nItems (1) + Number of WPs (2) +
+	// Database ID (1) + Route ID (1).
+	wpListHeaderBytes = 6
+	// wpFixedBytes is the per-waypoint wire size excluding the name text:
+	// WP ID (1) + latitude (4) + longitude (4) + string-LAU length/control
+	// bytes (2).
+	wpFixedBytes = 11
+
+	// maxN2KWaypoints: WP IDs in PGN 130067 are single bytes and the top
+	// values (253-255) are reserved in NMEA 2000.
+	maxN2KWaypoints = 252
+
+	defaultN2KRouteName = "Chartplotter"
+	defaultN2KDatabase  = 1
+	defaultN2KRoute     = 1
+)
+
+type n2kRouteOptions struct {
+	RouteName  string
+	DatabaseID int
+	RouteID    int
+	// Dst < 0 means leave it to the sender's default (broadcast).
+	Dst int
+}
+
+// parseN2KRouteOptions accepts the send_waypoints_n2k payload: either a
+// non-object truthy value for all defaults, or an options object. Numbers
+// arrive as float64 when the command crosses gRPC.
+func parseN2KRouteOptions(raw interface{}) (n2kRouteOptions, error) {
+	opts := n2kRouteOptions{
+		RouteName:  defaultN2KRouteName,
+		DatabaseID: defaultN2KDatabase,
+		RouteID:    defaultN2KRoute,
+		Dst:        -1,
+	}
+	m, ok := raw.(map[string]interface{})
+	if !ok {
+		return opts, nil
+	}
+	if v, ok := m["route_name"].(string); ok && v != "" {
+		opts.RouteName = v
+	}
+	for key, target := range map[string]*int{
+		"database_id": &opts.DatabaseID,
+		"route_id":    &opts.RouteID,
+		"dst":         &opts.Dst,
+	} {
+		v, present := m[key]
+		if !present {
+			continue
+		}
+		switch n := v.(type) {
+		case float64:
+			*target = int(n)
+		case int:
+			*target = n
+		default:
+			return opts, errors.Errorf("send_waypoints_n2k.%s must be a number, got %T", key, v)
+		}
+	}
+	if opts.DatabaseID < 0 || opts.DatabaseID > 252 {
+		return opts, errors.Errorf("send_waypoints_n2k.database_id out of range: %d", opts.DatabaseID)
+	}
+	if opts.RouteID < 0 || opts.RouteID > 252 {
+		return opts, errors.Errorf("send_waypoints_n2k.route_id out of range: %d", opts.RouteID)
+	}
+	if opts.Dst > 255 {
+		return opts, errors.Errorf("send_waypoints_n2k.dst out of range: %d", opts.Dst)
+	}
+	return opts, nil
+}
+
+func n2kWaypointName(i int) string {
+	return fmt.Sprintf("WP%03d", i+1)
+}
+
+// n2kSenderCmd wraps one PGN's fields into the sender component's DoCommand
+// shape.
+func n2kSenderCmd(pgn int, opts n2kRouteOptions, fields map[string]interface{}) map[string]interface{} {
+	cmd := map[string]interface{}{
+		"pgn":      pgn,
+		"priority": routeWPPriority,
+		"fields":   fields,
+	}
+	if opts.Dst >= 0 {
+		cmd["dst"] = opts.Dst
+	}
+	return cmd
+}
+
+// n2kRouteMessages builds the ordered sender commands that transfer the given
+// waypoint list: one 130066 attributes message, then 130067 name & position
+// messages chunked to fit a fast-packet each. Pure — no I/O — so the wire
+// content is unit-testable.
+func n2kRouteMessages(wps []navigation.Waypoint, opts n2kRouteOptions) ([]map[string]interface{}, error) {
+	if len(wps) == 0 {
+		return nil, errors.New("no waypoints to send")
+	}
+	if len(wps) > maxN2KWaypoints {
+		return nil, errors.Errorf("too many waypoints for one NMEA 2000 route: %d > %d", len(wps), maxN2KWaypoints)
+	}
+
+	total := len(wps)
+	msgs := []map[string]interface{}{
+		n2kSenderCmd(pgnRouteWPListAttributes, opts, map[string]interface{}{
+			"Database ID":                        opts.DatabaseID,
+			"Route ID":                           opts.RouteID,
+			"Route/WP-List Name":                 opts.RouteName,
+			"Number of WPs in the Route/WP-List": total,
+			// Remaining attribute fields (timestamps, navigation method,
+			// route status, XTE limit) are omitted on purpose: the canboat
+			// marshaller writes them as "unavailable".
+		}),
+	}
+
+	budget := fastPacketMaxBytes - wpListHeaderBytes
+	start := 0
+	for start < total {
+		used := 0
+		list := []interface{}{}
+		for i := start; i < total; i++ {
+			name := n2kWaypointName(i)
+			need := wpFixedBytes + len(name)
+			if used+need > budget {
+				break
+			}
+			used += need
+			list = append(list, map[string]interface{}{
+				"WP ID":        i,
+				"WP Name":      name,
+				"WP Latitude":  wps[i].Lat,
+				"WP Longitude": wps[i].Long,
+			})
+		}
+		msgs = append(msgs, n2kSenderCmd(pgnRouteWPNamePosition, opts, map[string]interface{}{
+			"Start RPS#":                         start,
+			"nItems":                             len(list),
+			"Number of WPs in the Route/WP-List": total,
+			"Database ID":                        opts.DatabaseID,
+			"Route ID":                           opts.RouteID,
+			"list":                               list,
+		}))
+		start += len(list)
+	}
+	return msgs, nil
+}
+
+// doSendWaypointsN2K handles {"send_waypoints_n2k": {...}}: it snapshots the
+// current (unvisited) waypoint list and pushes it out the configured
+// n2k_sender as an NMEA 2000 Route and WP Service transfer.
+func (s *navService) doSendWaypointsN2K(ctx context.Context, raw interface{}) (map[string]interface{}, error) {
+	if s.n2kSender == nil {
+		return nil, errors.New("send_waypoints_n2k: nav service has no n2k_sender configured")
+	}
+	opts, err := parseN2KRouteOptions(raw)
+	if err != nil {
+		return nil, err
+	}
+
+	s.mu.Lock()
+	wps, err := s.store.Waypoints(ctx)
+	s.mu.Unlock()
+	if err != nil {
+		return nil, err
+	}
+
+	msgs, err := n2kRouteMessages(wps, opts)
+	if err != nil {
+		return nil, err
+	}
+	for i, msg := range msgs {
+		if _, err := s.n2kSender.DoCommand(ctx, msg); err != nil {
+			return nil, errors.Wrapf(err, "send_waypoints_n2k: sender failed on message %d of %d (pgn %v)",
+				i+1, len(msgs), msg["pgn"])
+		}
+	}
+	s.logger.Infof("sent %d waypoints as n2k route %q (%d messages)", len(wps), opts.RouteName, len(msgs))
+	return map[string]interface{}{
+		"ok":         true,
+		"waypoints":  len(wps),
+		"messages":   len(msgs),
+		"route_name": opts.RouteName,
+	}, nil
+}

--- a/nav_n2k_test.go
+++ b/nav_n2k_test.go
@@ -1,0 +1,244 @@
+package vc
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	geo "github.com/kellydunn/golang-geo"
+	"github.com/pkg/errors"
+
+	"go.viam.com/rdk/logging"
+	"go.viam.com/rdk/resource"
+	"go.viam.com/rdk/services/navigation"
+)
+
+func mkWaypoints(n int) []navigation.Waypoint {
+	wps := make([]navigation.Waypoint, n)
+	for i := range wps {
+		wps[i] = navigation.Waypoint{Lat: 41.0 + float64(i)*0.01, Long: -71.5 - float64(i)*0.01}
+	}
+	return wps
+}
+
+func TestN2KRouteMessagesBasic(t *testing.T) {
+	opts, err := parseN2KRouteOptions(map[string]interface{}{"route_name": "Block Island Run"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	msgs, err := n2kRouteMessages(mkWaypoints(2), opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(msgs) != 2 {
+		t.Fatalf("expected 130066 + one 130067, got %d messages", len(msgs))
+	}
+
+	attrs := msgs[0]
+	if attrs["pgn"] != pgnRouteWPListAttributes || attrs["priority"] != routeWPPriority {
+		t.Fatalf("bad attributes envelope: %v", attrs)
+	}
+	if _, hasDst := attrs["dst"]; hasDst {
+		t.Fatalf("dst should be omitted by default: %v", attrs)
+	}
+	attrFields := attrs["fields"].(map[string]interface{})
+	if attrFields["Route/WP-List Name"] != "Block Island Run" {
+		t.Fatalf("route name = %v", attrFields["Route/WP-List Name"])
+	}
+	if attrFields["Number of WPs in the Route/WP-List"] != 2 {
+		t.Fatalf("wp count = %v", attrFields["Number of WPs in the Route/WP-List"])
+	}
+	if attrFields["Database ID"] != defaultN2KDatabase || attrFields["Route ID"] != defaultN2KRoute {
+		t.Fatalf("bad db/route ids: %v", attrFields)
+	}
+
+	wpMsg := msgs[1]
+	if wpMsg["pgn"] != pgnRouteWPNamePosition {
+		t.Fatalf("second message pgn = %v", wpMsg["pgn"])
+	}
+	wpFields := wpMsg["fields"].(map[string]interface{})
+	if wpFields["Start RPS#"] != 0 || wpFields["nItems"] != 2 {
+		t.Fatalf("bad chunk header: %v", wpFields)
+	}
+	list := wpFields["list"].([]interface{})
+	if len(list) != 2 {
+		t.Fatalf("list len = %d", len(list))
+	}
+	first := list[0].(map[string]interface{})
+	if first["WP ID"] != 0 || first["WP Name"] != "WP001" {
+		t.Fatalf("bad first waypoint: %v", first)
+	}
+	if first["WP Latitude"] != 41.0 || first["WP Longitude"] != -71.5 {
+		t.Fatalf("bad first position: %v", first)
+	}
+}
+
+func TestN2KRouteMessagesChunking(t *testing.T) {
+	const total = 40
+	opts, _ := parseN2KRouteOptions(nil)
+	msgs, err := n2kRouteMessages(mkWaypoints(total), opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(msgs) < 3 {
+		t.Fatalf("expected %d waypoints to need multiple 130067 chunks, got %d messages", total, len(msgs))
+	}
+
+	seen := 0
+	for _, msg := range msgs[1:] {
+		fields := msg["fields"].(map[string]interface{})
+		if fields["Start RPS#"] != seen {
+			t.Fatalf("chunk starts at %v, want %d", fields["Start RPS#"], seen)
+		}
+		if fields["Number of WPs in the Route/WP-List"] != total {
+			t.Fatalf("chunk total = %v", fields["Number of WPs in the Route/WP-List"])
+		}
+		list := fields["list"].([]interface{})
+		if len(list) != fields["nItems"] {
+			t.Fatalf("nItems %v != list len %d", fields["nItems"], len(list))
+		}
+
+		// Every chunk must fit one fast-packet: header + per-wp size.
+		size := wpListHeaderBytes
+		for i, item := range list {
+			wp := item.(map[string]interface{})
+			if wp["WP ID"] != seen+i {
+				t.Fatalf("wp id %v, want %d", wp["WP ID"], seen+i)
+			}
+			size += wpFixedBytes + len(wp["WP Name"].(string))
+		}
+		if size > fastPacketMaxBytes {
+			t.Fatalf("chunk marshals to %d bytes > fast-packet max %d", size, fastPacketMaxBytes)
+		}
+		seen += len(list)
+	}
+	if seen != total {
+		t.Fatalf("chunks cover %d waypoints, want %d", seen, total)
+	}
+}
+
+func TestN2KRouteMessagesLimits(t *testing.T) {
+	opts, _ := parseN2KRouteOptions(nil)
+	if _, err := n2kRouteMessages(nil, opts); err == nil {
+		t.Fatal("expected error for empty waypoint list")
+	}
+	if _, err := n2kRouteMessages(mkWaypoints(maxN2KWaypoints+1), opts); err == nil {
+		t.Fatal("expected error for oversized waypoint list")
+	}
+}
+
+func TestParseN2KRouteOptions(t *testing.T) {
+	// gRPC delivers numbers as float64; dst must flow through to the envelope.
+	opts, err := parseN2KRouteOptions(map[string]interface{}{
+		"database_id": 3.0, "route_id": 7.0, "dst": 42.0,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if opts.DatabaseID != 3 || opts.RouteID != 7 || opts.Dst != 42 {
+		t.Fatalf("parsed opts = %+v", opts)
+	}
+	cmd := n2kSenderCmd(pgnRouteWPListAttributes, opts, map[string]interface{}{})
+	if cmd["dst"] != 42 {
+		t.Fatalf("dst not forwarded: %v", cmd)
+	}
+
+	if _, err := parseN2KRouteOptions(map[string]interface{}{"dst": "everyone"}); err == nil {
+		t.Fatal("expected type error for string dst")
+	}
+	if _, err := parseN2KRouteOptions(map[string]interface{}{"route_id": 999.0}); err == nil {
+		t.Fatal("expected range error for route_id")
+	}
+
+	// Non-object payloads (e.g. `true`) mean "all defaults".
+	opts, err = parseN2KRouteOptions(true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if opts.RouteName != defaultN2KRouteName || opts.Dst != -1 {
+		t.Fatalf("default opts = %+v", opts)
+	}
+}
+
+// fakeN2KSender is a stand-in for the viamboat sender component: it records
+// every DoCommand payload.
+type fakeN2KSender struct {
+	resource.AlwaysRebuild
+	cmds []map[string]interface{}
+	err  error
+}
+
+func (f *fakeN2KSender) Name() resource.Name { return resource.Name{Name: "fake-sender"} }
+func (f *fakeN2KSender) Close(context.Context) error {
+	return nil
+}
+func (f *fakeN2KSender) Status(context.Context) (map[string]interface{}, error) {
+	return map[string]interface{}{}, nil
+}
+func (f *fakeN2KSender) DoCommand(_ context.Context, cmd map[string]interface{}) (map[string]interface{}, error) {
+	f.cmds = append(f.cmds, cmd)
+	if f.err != nil {
+		return nil, f.err
+	}
+	return map[string]interface{}{"sent": true}, nil
+}
+
+func TestDoSendWaypointsN2K(t *testing.T) {
+	ctx := context.Background()
+	st := tempStore(t)
+	if _, err := st.ReplaceWaypoints(ctx, []*geo.Point{
+		geo.NewPoint(41.1631, -71.5784),
+		geo.NewPoint(41.2042, -71.5511),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	sender := &fakeN2KSender{}
+	svc := &navService{logger: logging.NewTestLogger(t), store: st, n2kSender: sender}
+
+	out, err := svc.DoCommand(ctx, map[string]interface{}{
+		"send_waypoints_n2k": map[string]interface{}{"route_name": "Test Route"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out["ok"] != true || out["waypoints"] != 2 || out["messages"] != 2 {
+		t.Fatalf("unexpected response: %v", out)
+	}
+	if len(sender.cmds) != 2 {
+		t.Fatalf("sender got %d commands, want 2", len(sender.cmds))
+	}
+	if sender.cmds[0]["pgn"] != pgnRouteWPListAttributes || sender.cmds[1]["pgn"] != pgnRouteWPNamePosition {
+		t.Fatalf("wrong pgn order: %v, %v", sender.cmds[0]["pgn"], sender.cmds[1]["pgn"])
+	}
+}
+
+func TestDoSendWaypointsN2KErrors(t *testing.T) {
+	ctx := context.Background()
+
+	// No sender configured.
+	svc := &navService{logger: logging.NewTestLogger(t), store: tempStore(t)}
+	if _, err := svc.doSendWaypointsN2K(ctx, true); err == nil || !strings.Contains(err.Error(), "n2k_sender") {
+		t.Fatalf("expected no-sender error, got %v", err)
+	}
+
+	// Empty waypoint list.
+	svc = &navService{logger: logging.NewTestLogger(t), store: tempStore(t), n2kSender: &fakeN2KSender{}}
+	if _, err := svc.doSendWaypointsN2K(ctx, true); err == nil || !strings.Contains(err.Error(), "no waypoints") {
+		t.Fatalf("expected empty-list error, got %v", err)
+	}
+
+	// Sender failure surfaces with message context.
+	st := tempStore(t)
+	if _, err := st.ReplaceWaypoints(ctx, []*geo.Point{geo.NewPoint(1, 1)}); err != nil {
+		t.Fatal(err)
+	}
+	svc = &navService{
+		logger:    logging.NewTestLogger(t),
+		store:     st,
+		n2kSender: &fakeN2KSender{err: errors.New("bus offline")},
+	}
+	if _, err := svc.doSendWaypointsN2K(ctx, true); err == nil || !strings.Contains(err.Error(), "bus offline") {
+		t.Fatalf("expected sender error, got %v", err)
+	}
+}

--- a/src/lib/RoutesPanel.svelte
+++ b/src/lib/RoutesPanel.svelte
@@ -5,6 +5,7 @@
   // read lazily through a getter (the robot client is assigned asynchronously
   // and isn't a reactive prop), so the panel always sees the current value.
   import type { PositionPoint } from "./BoatInfo";
+  import { downloadGpx } from "./gpx";
   import { simplifyTrack, pathLengthMeters, type LatLng } from "./simplify";
   import {
     listRoutes,
@@ -364,6 +365,16 @@
     const d = new Date(iso);
     return isNaN(d.getTime()) ? "" : d.toLocaleDateString();
   }
+
+  // GPX export is client-side only (build the file, trigger a download) — for
+  // carrying a route to another plotter, e.g. Garmin/GPX/*.gpx on an SD card.
+  function exportCurrentGpx() {
+    const today = new Date().toISOString().slice(0, 10);
+    downloadGpx(
+      `Waypoints ${today}`,
+      currentWaypoints.map((w) => ({ lat: w.lat, lng: w.lng }))
+    );
+  }
 </script>
 
 <div class="flex flex-col gap-2 p-2 text-sm text-white">
@@ -467,6 +478,12 @@
                   disabled={busy}
                   title="Load this route in reverse (navigate the other way)">Reverse</button
                 >
+                <button
+                  class="px-1.5 py-0.5 border border-dark rounded hover:bg-dark"
+                  onclick={() => downloadGpx(r.name, r.waypoints)}
+                  title="Download this route as a GPX file (e.g. for a Garmin memory card)"
+                  >GPX</button
+                >
                 <!-- Inherited (parent-location) routes are read-only here. -->
                 {#if r.scope !== "parent"}
                   <button
@@ -538,6 +555,17 @@
         Save current waypoints…
       </button>
     {/if}
+
+    <button
+      class="px-2 py-0.5 border border-dark rounded hover:bg-dark disabled:opacity-40 text-xs"
+      onclick={exportCurrentGpx}
+      disabled={currentWaypoints.length === 0}
+      title={currentWaypoints.length === 0
+        ? "No active waypoints"
+        : "Download the current waypoints as a GPX route file (e.g. for a Garmin memory card)"}
+    >
+      Download current as GPX
+    </button>
 
     <!-- Capture recorded track as a route. -->
     {#if trackFormOpen}

--- a/src/lib/gpx.test.ts
+++ b/src/lib/gpx.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+import { routeToGpx, gpxFilename } from "./gpx";
+
+describe("routeToGpx", () => {
+  it("emits a route with named points and 1e-7 precision", () => {
+    const xml = routeToGpx("Block Island Run", [
+      { lat: 41.1631, lng: -71.5784 },
+      { lat: 41.2042, lng: -71.5511 },
+    ]);
+    expect(xml).toContain(`<gpx version="1.1"`);
+    expect(xml).toContain("<name>Block Island Run</name>");
+    expect(xml).toContain(`<rtept lat="41.1631000" lon="-71.5784000">`);
+    expect(xml).toContain("<name>Block Island Run 01</name>");
+    expect(xml).toContain("<name>Block Island Run 02</name>");
+    expect((xml.match(/<rtept /g) ?? []).length).toBe(2);
+  });
+
+  it("escapes XML in names", () => {
+    const xml = routeToGpx(`Tom & Jerry's <run>`, [{ lat: 1, lng: 2 }]);
+    expect(xml).toContain("<name>Tom &amp; Jerry&apos;s &lt;run&gt;</name>");
+    expect(xml).not.toContain("<run>");
+  });
+
+  it("falls back to a default name", () => {
+    const xml = routeToGpx("  ", [{ lat: 1, lng: 2 }]);
+    expect(xml).toContain("<name>Route</name>");
+    expect(xml).toContain("<name>Route 01</name>");
+  });
+});
+
+describe("gpxFilename", () => {
+  it("slugifies", () => {
+    expect(gpxFilename("Block Island Run")).toBe("block-island-run.gpx");
+    expect(gpxFilename("  A / B?  ")).toBe("a-b.gpx");
+    expect(gpxFilename("!!!")).toBe("route.gpx");
+  });
+});

--- a/src/lib/gpx.ts
+++ b/src/lib/gpx.ts
@@ -1,0 +1,64 @@
+// GPX 1.1 export of a waypoint list, shaped for chartplotter import (Garmin
+// units read routes from Garmin/GPX/*.gpx on a memory card). The route is
+// emitted as one <rte> whose <rtept>s carry sequential names so they're easy
+// to identify after import.
+import type { LatLng } from "./simplify";
+
+function escapeXml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+}
+
+// Waypoint names inside the route: "<prefix> 01", "<prefix> 02", … where the
+// prefix is the route name truncated to keep names short on plotter screens.
+function pointName(routeName: string, i: number): string {
+  const prefix = routeName.trim().slice(0, 20) || "WP";
+  return `${prefix} ${String(i + 1).padStart(2, "0")}`;
+}
+
+export function routeToGpx(name: string, waypoints: LatLng[]): string {
+  const displayName = name.trim() || "Route";
+  const pts = waypoints
+    .map(
+      (w, i) =>
+        `    <rtept lat="${w.lat.toFixed(7)}" lon="${w.lng.toFixed(7)}">\n` +
+        `      <name>${escapeXml(pointName(displayName, i))}</name>\n` +
+        `    </rtept>`
+    )
+    .join("\n");
+  return (
+    `<?xml version="1.0" encoding="UTF-8"?>\n` +
+    `<gpx version="1.1" creator="viam-chartplotter" xmlns="http://www.topografix.com/GPX/1/1">\n` +
+    `  <rte>\n` +
+    `    <name>${escapeXml(displayName)}</name>\n` +
+    pts +
+    `\n  </rte>\n` +
+    `</gpx>\n`
+  );
+}
+
+// Filesystem-safe download name derived from the route name.
+export function gpxFilename(name: string): string {
+  const slug = name
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return `${slug || "route"}.gpx`;
+}
+
+export function downloadGpx(name: string, waypoints: LatLng[]): void {
+  const blob = new Blob([routeToGpx(name, waypoints)], { type: "application/gpx+xml" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = gpxFilename(name);
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  URL.revokeObjectURL(url);
+}


### PR DESCRIPTION
## Summary
This PR adds two complementary features for exporting waypoints from the navigation service:
1. **NMEA 2000 Route and WP Service export** - sends waypoints to a configured N2K sender component for marine chartplotters
2. **GPX file download** - client-side export of routes as GPX files for import into other navigation systems

## Key Changes

### Backend (Go)
- **nav_n2k.go** (new): Implements NMEA 2000 Route and WP Service protocol
  - Builds PGN 130066 (Route/WP-List Attributes) and PGN 130067 (Route - WP Name & Position) messages
  - Chunks waypoints to fit NMEA 2000 fast-packet constraints (223 bytes max)
  - Supports up to 252 waypoints per route
  - Configurable route name, database ID, route ID, and destination address

- **nav_n2k_test.go** (new): Comprehensive test coverage
  - Tests basic message structure and field values
  - Tests chunking logic for large waypoint lists
  - Tests parameter validation and error handling
  - Integration test with mock N2K sender component

- **nav.go** (modified):
  - Added `N2KSender` config field to enable optional N2K export
  - Added `n2kSender` resource field to navService
  - Integrated N2K sender dependency resolution in newNav()
  - Added `send_waypoints_n2k` DoCommand handler

### Frontend (TypeScript/Svelte)
- **gpx.ts** (new): GPX 1.1 export utilities
  - `routeToGpx()`: Converts waypoint list to GPX XML with proper formatting
  - `gpxFilename()`: Generates filesystem-safe filenames from route names
  - `downloadGpx()`: Triggers browser download of GPX file
  - Proper XML escaping and 1e-7 coordinate precision

- **gpx.test.ts** (new): Unit tests for GPX generation
  - Tests XML structure and coordinate precision
  - Tests XML escaping of special characters
  - Tests filename slugification

- **RoutesPanel.svelte** (modified):
  - Added "GPX" button to each route for individual export
  - Added "Download current as GPX" button for active waypoints
  - Integrated client-side GPX download functionality

### Documentation
- **README.md** (modified): Updated configuration documentation with N2K sender setup and usage examples

## Implementation Details

- **N2K Protocol**: Follows NMEA 2000 fast-packet chunking rules; each message fits in a single CAN frame sequence
- **Waypoint Naming**: Sequential names (WP001, WP002, etc.) for easy identification on chartplotters
- **Error Handling**: Validates waypoint count limits, parameter ranges, and sender availability
- **Client-Side GPX**: No server round-trip required; uses browser Blob API for downloads
- **Backward Compatible**: N2K export is optional; GPX export works independently

https://claude.ai/code/session_01Eqj1zeNBVy6r3iVw9Drbhr